### PR TITLE
Category bug fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 3
-        versionName "1.0.0"
+        versionName "1.1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/willowtree/vocable/BaseActivity.kt
+++ b/app/src/main/java/com/willowtree/vocable/BaseActivity.kt
@@ -167,9 +167,11 @@ abstract class BaseActivity : AppCompatActivity() {
         if (!paused) {
             getAllViews().forEach {
                 if (viewIntersects(it, getPointerView())) {
-                    currentView = it
-                    (currentView as PointerListener).onPointerEnter()
-                    return
+                    if (it.isEnabled) {
+                        currentView = it
+                        (currentView as PointerListener).onPointerEnter()
+                        return
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/willowtree/vocable/customviews/CategoryButton.kt
+++ b/app/src/main/java/com/willowtree/vocable/customviews/CategoryButton.kt
@@ -15,7 +15,7 @@ class CategoryButton @JvmOverloads constructor(
     PointerListener {
 
     companion object {
-        private const val DEFAULT_TTS_TIMEOUT = 2000L
+        private const val DEFAULT_TTS_TIMEOUT = 1500L
     }
 
     private var buttonJob: Job? = null
@@ -23,6 +23,7 @@ class CategoryButton @JvmOverloads constructor(
     private val uiScope = CoroutineScope(Dispatchers.Main)
 
     init {
+        isEnabled = false
         setOnClickListener {
             isSelected = true
             sayText(text)
@@ -31,6 +32,9 @@ class CategoryButton @JvmOverloads constructor(
     }
 
     override fun onPointerEnter() {
+        if (isSelected) {
+            return
+        }
         buttonJob = backgroundScope.launch {
             uiScope.launch {
                 isPressed = true

--- a/app/src/main/java/com/willowtree/vocable/presets/CategoriesFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/CategoriesFragment.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.core.view.children
+import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import com.willowtree.vocable.BaseFragment
@@ -69,7 +71,7 @@ class CategoriesFragment : BaseFragment() {
                     CategoryButtonBinding.inflate(inflater, binding?.categoryButtonContainer, false)
                 binding?.categoryButtonContainer?.addView(hiddenButton.root.apply {
                     isEnabled = false
-                    visibility = View.INVISIBLE
+                    isInvisible = true
                 })
             }
         }
@@ -80,6 +82,24 @@ class CategoriesFragment : BaseFragment() {
         super.onViewCreated(view, savedInstanceState)
         viewModel = ViewModelProviders.of(requireActivity()).get(PresetsViewModel::class.java)
         subscribeToViewModel()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        binding?.categoryButtonContainer?.children?.forEach {
+            if (it is CategoryButton && it.isVisible) {
+                it.isEnabled = true
+            }
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        binding?.categoryButtonContainer?.children?.forEach {
+            if (it is CategoryButton) {
+                it.isEnabled = false
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
@@ -204,6 +204,7 @@ class PresetsFragment : BaseFragment() {
         presetsViewModel.categoryList.observe(viewLifecycleOwner, Observer {
             it?.let { categories ->
                 with(binding?.categoryView) {
+                    this?.isSaveEnabled = false
                     this?.adapter = categoriesAdapter
                     categoriesAdapter.setCategories(categories)
                     // Move adapter to middle so user can scroll both directions
@@ -224,6 +225,7 @@ class PresetsFragment : BaseFragment() {
         presetsViewModel.currentPhrases.observe(viewLifecycleOwner, Observer {
             it?.let { phrases ->
                 with(binding?.phrasesView) {
+                    this?.isSaveEnabled = false
                     this?.adapter = phrasesAdapter
                     phrasesAdapter.setPhrases(phrases)
                     // Move adapter to middle so user can scroll both directions


### PR DESCRIPTION
- The incorrect number of categories and phrases was sometimes appearing after rotation. This was due to the `FragmentStateAdapter` caching fragments between orientation changes. Set `isSaveEnabled` to false to fix this
- Sometimes the category paging buttons couldn't be clicked due to "off-screen" category buttons blocking them. Added logic to disable category buttons until they're on screen again