### PR TITLE
Restore selected category position on config change

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.2.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.fragment:fragment:1.2.3'
     // Provides ARCore Session and related resources.

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
@@ -229,9 +229,9 @@ class PresetsFragment : BaseFragment() {
     }
 
     private fun handleCategories(categories: List<Category>) {
-        with(binding?.categoryView) {
-            this?.isSaveEnabled = false
-            this?.adapter = categoriesAdapter
+        binding?.categoryView?.apply {
+            isSaveEnabled = false
+            adapter = categoriesAdapter
             categoriesAdapter.setItems(categories)
 
             // The categories ViewPager position will initially be set to the middle so that the
@@ -247,21 +247,21 @@ class PresetsFragment : BaseFragment() {
                 for (i in targetPosition until targetPosition + categoriesAdapter.numPages) {
                     val pageCategories = categoriesAdapter.getItemsByPosition(i)
 
-                    if (pageCategories.find { pageCategory -> pageCategory.categoryId == selectedCategory.categoryId } != null) {
+                    if (pageCategories.find { it.categoryId == selectedCategory.categoryId } != null) {
                         targetPosition = i
                         break
                     }
                 }
             }
 
-            this?.setCurrentItem(targetPosition, false)
+            setCurrentItem(targetPosition, false)
         }
     }
 
     private fun handlePhrases(phrases: List<Phrase>) {
-        with(binding?.phrasesView) {
-            this?.isSaveEnabled = false
-            this?.adapter = phrasesAdapter
+        binding?.phrasesView?.apply {
+            isSaveEnabled = false
+            adapter = phrasesAdapter
 
             maxPhrases =
                 if (presetsViewModel.selectedCategory.value?.categoryId == getString(R.string.category_123_id)) {
@@ -274,10 +274,10 @@ class PresetsFragment : BaseFragment() {
             // Move adapter to middle so user can scroll both directions
             val middle = phrasesAdapter.itemCount / 2
             if (middle % phrasesAdapter.numPages == 0) {
-                this?.setCurrentItem(middle, false)
+                setCurrentItem(middle, false)
             } else {
                 val mod = middle % phrasesAdapter.numPages
-                this?.setCurrentItem(
+                setCurrentItem(
                     middle + (phrasesAdapter.numPages - mod),
                     false
                 )

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
@@ -2,7 +2,6 @@ package com.willowtree.vocable.presets
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,6 +11,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.observe
 import androidx.viewpager2.widget.ViewPager2
 import com.willowtree.vocable.BaseFragment
 import com.willowtree.vocable.BaseViewModelFactory
@@ -26,13 +26,8 @@ import com.willowtree.vocable.settings.SettingsActivity
 import com.willowtree.vocable.utils.SpokenText
 import com.willowtree.vocable.utils.VocableFragmentStateAdapter
 import com.willowtree.vocable.utils.VocableTextToSpeech
-import kotlin.math.min
 
 class PresetsFragment : BaseFragment() {
-
-    companion object {
-        private const val KEY_CATEGORY_POSITION = "KEY_CATEGORY_POSITION"
-    }
 
     private var binding: FragmentPresetsBinding? = null
     private val allViews = mutableListOf<View>()
@@ -43,8 +38,6 @@ class PresetsFragment : BaseFragment() {
     private lateinit var presetsViewModel: PresetsViewModel
     private lateinit var categoriesAdapter: CategoriesPagerAdapter
     private lateinit var phrasesAdapter: PhrasesPagerAdapter
-
-    private var categoryPosition: Int? = 0
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -176,8 +169,6 @@ class PresetsFragment : BaseFragment() {
             }
         })
 
-        categoryPosition = savedInstanceState?.getInt(KEY_CATEGORY_POSITION)
-
         SpokenText.postValue(null)
 
         presetsViewModel =
@@ -201,11 +192,6 @@ class PresetsFragment : BaseFragment() {
         presetsViewModel.populateCategories()
     }
 
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putInt(KEY_CATEGORY_POSITION, binding?.categoryView?.currentItem ?: 0)
-    }
-
     private fun subscribeToViewModel() {
         SpokenText.observe(viewLifecycleOwner, Observer {
             binding?.currentText?.text = if (it.isNullOrBlank()) {
@@ -219,63 +205,10 @@ class PresetsFragment : BaseFragment() {
             binding?.speakerIcon?.isVisible = it ?: false
         })
 
-        presetsViewModel.categoryList.observe(viewLifecycleOwner, Observer {
-            it?.let { categories ->
-                with(binding?.categoryView) {
-                    this?.isSaveEnabled = false
-                    this?.adapter = categoriesAdapter
-                    categoriesAdapter.setItems(categories)
-
-                    // Restore saved position if it exists, otherwise jump to middle
-                    if (categoryPosition != null ) {
-                        Log.e("JS", "Restoring categoryPosition: $categoryPosition")
-                        categoryPosition?.let { categoryPosition -> binding?.categoryView?.currentItem = categoryPosition }
-                    } else {
-                        Log.e("JS", "Selecting center item")
-                        // Move adapter to middle so user can scroll both directions
-                        val middle = categoriesAdapter.itemCount / 2
-                        if (middle % categoriesAdapter.numPages == 0) {
-                            binding?.categoryView?.setCurrentItem(middle, false)
-                        } else {
-                            val mod = middle % categoriesAdapter.numPages
-                            binding?.categoryView?.setCurrentItem(
-                                middle + (categoriesAdapter.numPages - mod),
-                                false
-                            )
-                        }
-                    }
-                }
-            }
-        })
-
-        presetsViewModel.currentPhrases.observe(viewLifecycleOwner, Observer {
-            it?.let { phrases ->
-                with(binding?.phrasesView) {
-                    this?.isSaveEnabled = false
-                    this?.adapter = phrasesAdapter
-
-                    maxPhrases =
-                        if (presetsViewModel.selectedCategory.value?.categoryId == getString(R.string.category_123_id)) {
-                            NumberPadFragment.MAX_PHRASES
-                        } else {
-                            resources.getInteger(R.integer.max_phrases)
-                        }
-
-                    phrasesAdapter.setItems(phrases)
-                    // Move adapter to middle so user can scroll both directions
-                    val middle = phrasesAdapter.itemCount / 2
-                    if (middle % phrasesAdapter.numPages == 0) {
-                        binding?.phrasesView?.setCurrentItem(middle, false)
-                    } else {
-                        val mod = middle % phrasesAdapter.numPages
-                        binding?.phrasesView?.setCurrentItem(
-                            middle + (phrasesAdapter.numPages - mod),
-                            false
-                        )
-                    }
-                }
-            }
-        })
+        presetsViewModel.apply {
+            categoryList.observe(viewLifecycleOwner, ::handleCategories)
+            currentPhrases.observe(viewLifecycleOwner, ::handlePhrases)
+        }
     }
 
     override fun getAllViews(): List<View> {
@@ -295,20 +228,69 @@ class PresetsFragment : BaseFragment() {
         }
     }
 
+    private fun handleCategories(categories: List<Category>) {
+        with(binding?.categoryView) {
+            this?.isSaveEnabled = false
+            this?.adapter = categoriesAdapter
+            categoriesAdapter.setItems(categories)
+
+            // The categories ViewPager position will initially be set to the middle so that the
+            // user can scroll in both directions. Upon subsequent config changes, the position
+            // will be set to the closest page to the middle which contains the selected category.
+            var targetPosition = categoriesAdapter.itemCount / 2
+
+            if (targetPosition % categoriesAdapter.numPages != 0) {
+                targetPosition %= categoriesAdapter.numPages
+            }
+
+            presetsViewModel.selectedCategory.value?.let { selectedCategory ->
+                for (i in targetPosition until targetPosition + categoriesAdapter.numPages) {
+                    val pageCategories = categoriesAdapter.getItemsByPosition(i)
+
+                    if (pageCategories.find { pageCategory -> pageCategory.categoryId == selectedCategory.categoryId } != null) {
+                        targetPosition = i
+                        break
+                    }
+                }
+            }
+
+            this?.setCurrentItem(targetPosition, false)
+        }
+    }
+
+    private fun handlePhrases(phrases: List<Phrase>) {
+        with(binding?.phrasesView) {
+            this?.isSaveEnabled = false
+            this?.adapter = phrasesAdapter
+
+            maxPhrases =
+                if (presetsViewModel.selectedCategory.value?.categoryId == getString(R.string.category_123_id)) {
+                    NumberPadFragment.MAX_PHRASES
+                } else {
+                    resources.getInteger(R.integer.max_phrases)
+                }
+
+            phrasesAdapter.setItems(phrases)
+            // Move adapter to middle so user can scroll both directions
+            val middle = phrasesAdapter.itemCount / 2
+            if (middle % phrasesAdapter.numPages == 0) {
+                this?.setCurrentItem(middle, false)
+            } else {
+                val mod = middle % phrasesAdapter.numPages
+                this?.setCurrentItem(
+                    middle + (phrasesAdapter.numPages - mod),
+                    false
+                )
+            }
+        }
+    }
+
     inner class CategoriesPagerAdapter(fm: FragmentManager) :
         VocableFragmentStateAdapter<Category>(fm, viewLifecycleOwner.lifecycle) {
 
         override fun getMaxItemsPerPage(): Int = maxCategories
 
-        override fun createFragment(position: Int): Fragment {
-            val startPosition = (position % numPages) * maxCategories
-            val subList = items.subList(
-                startPosition,
-                min(items.size, startPosition + maxCategories)
-            )
-
-            return CategoriesFragment.newInstance(subList)
-        }
+        override fun createFragment(position: Int) = CategoriesFragment.newInstance(getItemsByPosition(position))
     }
 
     inner class PhrasesPagerAdapter(fm: FragmentManager) :
@@ -330,17 +312,14 @@ class PresetsFragment : BaseFragment() {
         override fun getMaxItemsPerPage(): Int = maxPhrases
 
         override fun createFragment(position: Int): Fragment {
-
-            val startPosition = (position % numPages) * maxPhrases
-            val sublist =
-                items.subList(startPosition, min(items.size, startPosition + maxPhrases))
+            val phrases = getItemsByPosition(position)
 
             return if (presetsViewModel.selectedCategory.value?.categoryId == getString(R.string.category_123_id)) {
-                NumberPadFragment.newInstance(sublist)
+                NumberPadFragment.newInstance(phrases)
             } else if (presetsViewModel.selectedCategory.value?.categoryId == getString(R.string.category_my_sayings_id) && items.isEmpty()) {
                 MySayingsEmptyFragment.newInstance(false)
             } else {
-                PhrasesFragment.newInstance(sublist)
+                PhrasesFragment.newInstance(phrases)
             }
         }
 

--- a/app/src/main/java/com/willowtree/vocable/utils/VocableFragmentStateAdapter.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/VocableFragmentStateAdapter.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import kotlin.math.ceil
+import kotlin.math.min
 
 /**
  * A custom implementation of FragmentStateAdapter to solve an issue with fragments not being
@@ -52,6 +53,21 @@ abstract class VocableFragmentStateAdapter<T>(fm: FragmentManager, lifecycle: Li
     override fun containsItem(itemId: Long): Boolean {
         val position = baseId - itemId
         return position in 0 until itemCount
+    }
+
+    /**
+     * Returns the list of items held by the page at the provided position.
+     */
+    fun getItemsByPosition(position: Int): List<T> {
+        val pageItems = mutableListOf<T>()
+        val startPosition = (position % numPages) * getMaxItemsPerPage()
+
+        pageItems.addAll(items.subList(
+            startPosition,
+            min(items.size, startPosition + getMaxItemsPerPage())
+        ))
+
+        return pageItems
     }
 
     abstract fun getMaxItemsPerPage(): Int


### PR DESCRIPTION
Upon config change, this will find the page closest to the middle in the category ViewPager which contains the currently selected category. This was a bit more involved than I thought. Please review carefully and if anyone has an alternative solution, I'm interested to hear it!

Also extracted category and phrase handling to their own functions so that subscribeToViewModel isn't so bloated.