### PR TITLE
Fix crash when drilling down into a category

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesFragment.kt
@@ -107,7 +107,7 @@ class EditCategoriesFragment : BaseFragment<FragmentEditCategoriesBinding>() {
     }
 
     private fun subscribeToViewModel() {
-        editCategoriesViewModel.addRemoveCategoryList.observe(requireActivity(), Observer {
+        editCategoriesViewModel.addRemoveCategoryList.observe(viewLifecycleOwner, Observer {
             it?.let { categories ->
                 binding.editCategoriesViewPager.apply {
                     isSaveEnabled = false
@@ -128,7 +128,7 @@ class EditCategoriesFragment : BaseFragment<FragmentEditCategoriesBinding>() {
             }
         })
 
-        editCategoriesViewModel.lastViewedIndex.observe(requireActivity(), Observer {
+        editCategoriesViewModel.lastViewedIndex.observe(viewLifecycleOwner, Observer {
             it?.let { index ->
                 val pageNum = index / maxEditCategories
                 val middle = categoriesAdapter.itemCount / 2


### PR DESCRIPTION
Fragments should use viewLifecycleOwner rather than the activity when observing LiveData, otherwise there's the potential for LiveData to be observed after the view has been destroyed.