### PR TITLE
Unregister Idling Resource

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/screens/MainScreen.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/screens/MainScreen.kt
@@ -53,6 +53,11 @@ class MainScreen {
         onView(withText(phraseText)).tap()
     }
 
+    // This function verifies that we are on the Main Screen
+    fun checkOnMainScreen(){
+        currentText.check(matches(isDisplayed()))
+    }
+
     // Edit Text box and action buttons
     val currentText = onView(withId(R.id.current_text))
     val keyboardNavitgationButton = onView(withId(R.id.keyboard_button))

--- a/app/src/androidTest/java/com/willowtree/vocable/tests/BaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/tests/BaseTest.kt
@@ -10,6 +10,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.willowtree.vocable.R
+import com.willowtree.vocable.screens.MainScreen
 import com.willowtree.vocable.splash.SplashActivity
 import com.willowtree.vocable.utility.SplashScreenIdlingResource
 import org.junit.After
@@ -42,15 +43,20 @@ open class BaseTest {
         IdlingPolicies.setIdlingResourceTimeout(10, TimeUnit.SECONDS)
         idleRegistry.register(idlingResource)
         activityRule.launchActivity(Intent())
+
+        // Since the build machine gets wiped after every run we can check the file storage
+        // of the emulator to determine if this is a first time launch
+        // and dismiss the full screen immersive popup on android if it is
         firstLaunch = getInstrumentation().targetContext.filesDir.listFiles().isEmpty()
         if (firstLaunch) {
             takeScreenshot("InitialSetup")
             dismissFullscreenPrompt()
         }
-    }
 
-    @After
-    open fun teardown() {
+        // Once we confirm we are on the MainScreen we need to unregister the Splash Screen
+        // idling resource so that we don't transition back to a not idle state when we
+        // navigate off of the main screen which would cause a timeout exception
+        MainScreen().checkOnMainScreen()
         idleRegistry.unregister(idlingResource)
     }
 

--- a/app/src/androidTest/java/com/willowtree/vocable/tests/MainScreenTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/tests/MainScreenTest.kt
@@ -15,7 +15,7 @@ class MainScreenTest : BaseTest() {
     @Test
     fun verifyClickingPhraseUpdatesCurrentText() {
         mainScreen.apply {
-            mainScreen.tapPhrase(defaultPhraseGeneral[0])
+            tapPhrase(defaultPhraseGeneral[0])
             currentText.assertTextMatches(defaultPhraseGeneral[0])
         }
     }
@@ -31,7 +31,7 @@ class MainScreenTest : BaseTest() {
     @Test
     fun verifyDefaultCategoriesExist() {
         mainScreen.apply {
-            mainScreen.verifyDefaultCategoriesExist()
+            verifyDefaultCategoriesExist()
         }
     }
 


### PR DESCRIPTION
Description: 
Unregister the idling resource once we confirm we are on the main screen otherwise the idling resource will timeout if we navigate to a different screen. Also cleanup some calls in MainScreenTest where we were unnecessarily calling `mainScreen`

Screenshots: 
N/A

- [N/A] Acceptance Criteria satisfied
- [N/A] Regression Testing
