### PR TITLE
drop keyboard min to 12sp

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -81,7 +81,7 @@
 
     <!-- Keyboard -->
     <dimen name="keyboard_text_size">48sp</dimen>
-    <dimen name="keyboard_text_min_size">22sp</dimen>
+    <dimen name="keyboard_text_min_size">12sp</dimen>
     <dimen name="keyboard_text_size_granularity">2sp</dimen>
     <dimen name="keyboard_side_margin">24dp</dimen>
     <dimen name="keyboard_predictive_height">120dp</dimen>


### PR DESCRIPTION
Description: 
* Drops keyboard scaling to 12sp to support max screen zoom
<img width="597" alt="Screen Shot 2020-05-22 at 4 00 15 PM" src="https://user-images.githubusercontent.com/21198695/82705423-9eda3b00-9c45-11ea-9f9c-54be5889586a.png">
