### PR TITLE
Fix long phrase edits

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/settings/EditKeyboardFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditKeyboardFragment.kt
@@ -45,6 +45,8 @@ abstract class EditKeyboardFragment : BaseFragment<FragmentEditKeyboardBinding>(
                 keyText.toLowerCase(Locale.getDefault())
             )
         }
+
+        binding.keyboardInput.setSelection(binding.keyboardInput.text.length)
     }
 
     fun isDefaultTextVisible(): Boolean {
@@ -102,6 +104,7 @@ abstract class EditKeyboardFragment : BaseFragment<FragmentEditKeyboardBinding>(
             if (!isDefaultTextVisible()) {
                 binding.keyboardInput.let { keyboardInput ->
                     keyboardInput.setText(keyboardInput.text.toString().dropLast(1))
+                    keyboardInput.setSelection(keyboardInput.text.length)
                     if (keyboardInput.text.isNullOrEmpty()) {
                         keyboardInput.setText(R.string.keyboard_select_letters)
                     }


### PR DESCRIPTION
Description: 
Sets "cursor" placement of input text to the end any time a change is made to it.  This guarantees that the end of the phrase is always shown, even if the phrase is very long

Fixes #224 

- [ ] Acceptance Criteria satisfied
- [ ] Regression Testing
