### PR TITLE
Add empty state to main page custom category

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
@@ -24,6 +24,7 @@ import com.willowtree.vocable.settings.SettingsActivity
 import com.willowtree.vocable.utils.SpokenText
 import com.willowtree.vocable.utils.VocableFragmentStateAdapter
 import com.willowtree.vocable.utils.VocableTextToSpeech
+import kotlinx.android.synthetic.main.fragment_presets.*
 
 class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
 
@@ -36,6 +37,8 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
     private lateinit var presetsViewModel: PresetsViewModel
     private lateinit var categoriesAdapter: CategoriesPagerAdapter
     private lateinit var phrasesAdapter: PhrasesPagerAdapter
+
+    private var isMySayingShowing = false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -111,6 +114,8 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
                         activity.resetAllViews()
                     }
                 }
+
+                isMySayingShowing = categoriesAdapter.getItemsByPosition(position)[0].categoryId == PresetCategories.USER_FAVORITES.id
             }
         })
 
@@ -215,8 +220,8 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
     }
 
     private fun handlePhrases(phrases: List<Phrase>) {
-        binding.emptyPhrasesText.isVisible = phrases.isEmpty()
-        binding.emptyAddPhraseButton.isVisible = phrases.isEmpty()
+        binding.emptyPhrasesText.isVisible = phrases.isEmpty() && !isMySayingShowing
+        binding.emptyAddPhraseButton.isVisible = phrases.isEmpty() && !isMySayingShowing
 
         binding.phrasesView.apply {
             isSaveEnabled = false

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
@@ -19,6 +19,7 @@ import com.willowtree.vocable.databinding.FragmentPresetsBinding
 import com.willowtree.vocable.keyboard.KeyboardFragment
 import com.willowtree.vocable.room.Category
 import com.willowtree.vocable.room.Phrase
+import com.willowtree.vocable.settings.EditCategoryOptionsFragmentDirections
 import com.willowtree.vocable.settings.SettingsActivity
 import com.willowtree.vocable.utils.SpokenText
 import com.willowtree.vocable.utils.VocableFragmentStateAdapter
@@ -91,6 +92,11 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
 
         binding.actionButtonContainer.settingsButton.action = {
             findNavController().navigate(R.id.action_presetsFragment_to_settingsActivity)
+        }
+
+        binding.emptyAddPhraseButton.action = {
+            val action = PresetsFragmentDirections.actionPresetsFragmentToKeyboardFragment()
+            findNavController().navigate(action)
         }
 
         categoriesAdapter = CategoriesPagerAdapter(childFragmentManager)
@@ -209,6 +215,9 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
     }
 
     private fun handlePhrases(phrases: List<Phrase>) {
+        binding.emptyPhrasesText.isVisible = phrases.isEmpty()
+        binding.emptyAddPhraseButton.isVisible = phrases.isEmpty()
+
         binding.phrasesView.apply {
             isSaveEnabled = false
             adapter = phrasesAdapter

--- a/app/src/main/res/layout-land/fragment_presets.xml
+++ b/app/src/main/res/layout-land/fragment_presets.xml
@@ -85,6 +85,32 @@
         app:layout_constraintBottom_toTopOf="@+id/phrases_back_button"
         app:layout_constraintTop_toBottomOf="@+id/category_view" />
 
+    <TextView
+        android:id="@+id/empty_phrases_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/custom_category_empty"
+        style="@style/CustomCategoryEmptyText"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_constraintWidth_percent=".75"
+        app:layout_constraintTop_toTopOf="@id/phrases_view"
+        app:layout_constraintBottom_toTopOf="@id/empty_add_phrase_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <com.willowtree.vocable.customviews.KeyboardButton
+        android:id="@+id/empty_add_phrase_button"
+        android:layout_width="0dp"
+        android:layout_height="64dp"
+        android:background="@drawable/button_default_background"
+        android:text="@string/add_phrase"
+        style="@style/CustomCategoryEmptyButton"
+        app:layout_constraintWidth_percent="0.25"
+        app:layout_constraintTop_toBottomOf="@id/empty_phrases_text"
+        app:layout_constraintStart_toStartOf="@id/empty_phrases_text"
+        app:layout_constraintEnd_toEndOf="@id/empty_phrases_text"
+        app:layout_constraintBottom_toBottomOf="@id/phrases_view"/>
+
     <com.willowtree.vocable.customviews.VocableImageButton
         android:id="@+id/phrases_back_button"
         android:layout_width="@dimen/phrases_paging_button_width"

--- a/app/src/main/res/layout-land/fragment_presets.xml
+++ b/app/src/main/res/layout-land/fragment_presets.xml
@@ -101,7 +101,7 @@
     <com.willowtree.vocable.customviews.KeyboardButton
         android:id="@+id/empty_add_phrase_button"
         android:layout_width="0dp"
-        android:layout_height="64dp"
+        android:layout_height="@dimen/custom_category_button_height"
         android:background="@drawable/button_default_background"
         android:text="@string/add_phrase"
         style="@style/CustomCategoryEmptyButton"

--- a/app/src/main/res/layout-sw600dp/fragment_presets.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_presets.xml
@@ -84,6 +84,32 @@
         app:layout_constraintBottom_toTopOf="@+id/phrases_back_button"
         app:layout_constraintTop_toBottomOf="@+id/category_view" />
 
+    <TextView
+        android:id="@+id/empty_phrases_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/custom_category_empty"
+        style="@style/CustomCategoryEmptyText"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_constraintWidth_percent=".75"
+        app:layout_constraintTop_toTopOf="@id/phrases_view"
+        app:layout_constraintBottom_toTopOf="@id/empty_add_phrase_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <com.willowtree.vocable.customviews.KeyboardButton
+        android:id="@+id/empty_add_phrase_button"
+        android:layout_width="0dp"
+        android:layout_height="64dp"
+        android:background="@drawable/button_default_background"
+        android:text="@string/add_phrase"
+        style="@style/CustomCategoryEmptyButton"
+        app:layout_constraintWidth_percent="0.25"
+        app:layout_constraintTop_toBottomOf="@id/empty_phrases_text"
+        app:layout_constraintStart_toStartOf="@id/empty_phrases_text"
+        app:layout_constraintEnd_toEndOf="@id/empty_phrases_text"
+        app:layout_constraintBottom_toBottomOf="@id/phrases_view"/>
+
     <com.willowtree.vocable.customviews.VocableImageButton
         android:id="@+id/phrases_back_button"
         android:layout_width="@dimen/phrases_paging_button_width"

--- a/app/src/main/res/layout-sw600dp/fragment_presets.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_presets.xml
@@ -100,7 +100,7 @@
     <com.willowtree.vocable.customviews.KeyboardButton
         android:id="@+id/empty_add_phrase_button"
         android:layout_width="0dp"
-        android:layout_height="64dp"
+        android:layout_height="@dimen/custom_category_button_height"
         android:background="@drawable/button_default_background"
         android:text="@string/add_phrase"
         style="@style/CustomCategoryEmptyButton"

--- a/app/src/main/res/layout/fragment_presets.xml
+++ b/app/src/main/res/layout/fragment_presets.xml
@@ -103,7 +103,7 @@
     <com.willowtree.vocable.customviews.KeyboardButton
         android:id="@+id/empty_add_phrase_button"
         android:layout_width="0dp"
-        android:layout_height="64dp"
+        android:layout_height="@dimen/custom_category_button_height"
         android:background="@drawable/button_default_background"
         android:text="@string/add_phrase"
         style="@style/CustomCategoryEmptyButton"

--- a/app/src/main/res/layout/fragment_presets.xml
+++ b/app/src/main/res/layout/fragment_presets.xml
@@ -87,6 +87,33 @@
         app:layout_constraintBottom_toTopOf="@+id/phrases_back_button"
         app:layout_constraintTop_toBottomOf="@+id/category_view" />
 
+    <TextView
+        android:id="@+id/empty_phrases_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/custom_category_empty"
+        style="@style/CustomCategoryEmptyText"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_constraintWidth_percent=".75"
+        app:layout_constraintTop_toTopOf="@id/phrases_view"
+        app:layout_constraintBottom_toTopOf="@id/empty_add_phrase_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <com.willowtree.vocable.customviews.KeyboardButton
+        android:id="@+id/empty_add_phrase_button"
+        android:layout_width="0dp"
+        android:layout_height="64dp"
+        android:background="@drawable/button_default_background"
+        android:text="@string/add_phrase"
+        style="@style/CustomCategoryEmptyButton"
+        android:visibility="visible"
+        app:layout_constraintWidth_percent="0.4"
+        app:layout_constraintTop_toBottomOf="@id/empty_phrases_text"
+        app:layout_constraintStart_toStartOf="@id/empty_phrases_text"
+        app:layout_constraintEnd_toEndOf="@id/empty_phrases_text"
+        app:layout_constraintBottom_toBottomOf="@id/phrases_view"/>
+
     <com.willowtree.vocable.customviews.VocableImageButton
         android:id="@+id/phrases_back_button"
         android:layout_width="@dimen/phrases_paging_button_width"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -263,5 +263,6 @@
     <dimen name="category_edit_button_hidden_margin_start">16dp</dimen>
     <dimen name="category_edit_button_hidden_margin_end">8dp</dimen>
     <dimen name="custom_category_button_text_size">22sp</dimen>
+    <dimen name="custom_category_button_height">64dp</dimen>
 
 </resources>


### PR DESCRIPTION
Description: 
Adds an empty state for custom category to the main presets screen.  Right now, the Add Phrase button will bring you to the keyboard, but saving the phrase from there will add the phrase to My Sayings, not the category you came from.  This will be changed in a future PR, where we will add the page with multiple switches to choose which categories a new phrase goes into.

Closes #281 

- [ ] Acceptance Criteria satisfied
- [ ] Regression Testing
