### PR TITLE
Check for duplicate category names

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/settings/EditKeyboardFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditKeyboardFragment.kt
@@ -6,10 +6,8 @@ import android.text.TextWatcher
 import android.view.View
 import androidx.core.view.children
 import androidx.core.view.isVisible
-import androidx.recyclerview.widget.GridLayoutManager
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
 import com.willowtree.vocable.BaseFragment
 import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
@@ -123,19 +121,28 @@ abstract class EditKeyboardFragment : BaseFragment<FragmentEditKeyboardBinding>(
 
     fun showConfirmationDialog() {
         setSettingsButtonsEnabled(false)
-        binding.editConfirmation.dialogTitle.text = getString(R.string.are_you_sure)
-        binding.editConfirmation.dialogMessage.text = getString(R.string.back_warning)
-        binding.editConfirmation.dialogPositiveButton.apply {
-            text = getString(R.string.contiue_editing)
-            action = {
-                toggleDialogVisibility(false)
-                setSettingsButtonsEnabled(true)
+        with(binding.editConfirmation) {
+            dialogTitle.text = getString(R.string.are_you_sure)
+            dialogTitle.isVisible = true
+
+            dialogMessage.text = getString(R.string.back_warning)
+            dialogMessage.isVisible = true
+
+            with(dialogPositiveButton) {
+                text = getString(R.string.contiue_editing)
+                action = {
+                    toggleDialogVisibility(false)
+                    setSettingsButtonsEnabled(true)
+                }
+                isVisible = true
             }
-        }
-        binding.editConfirmation.dialogNegativeButton.apply {
-            text = getString(R.string.discard)
-            action = {
-                findNavController().popBackStack()
+
+            with(dialogNegativeButton) {
+                text = getString(R.string.discard)
+                action = {
+                    findNavController().popBackStack()
+                }
+                isVisible = true
             }
         }
         toggleDialogVisibility(true)

--- a/app/src/main/res/layout-sw600dp/vocable_confirmation_dialog.xml
+++ b/app/src/main/res/layout-sw600dp/vocable_confirmation_dialog.xml
@@ -24,8 +24,9 @@
         style="@style/ConfirmationDialogText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/dialog_text_margin"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/dialog_title"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/dialog_title"
         tools:text="You're about to be taken outside of the app. You may lose head tracking control." />
 
@@ -33,8 +34,8 @@
         android:id="@+id/dialog_positive_button"
         style="@style/ConfirmationDialogButton"
         android:paddingStart="@dimen/dialog_button_padding_horizontal"
-        android:paddingEnd="@dimen/dialog_button_padding_horizontal"
         android:paddingTop="@dimen/dialog_button_padding_vertical"
+        android:paddingEnd="@dimen/dialog_button_padding_horizontal"
         android:paddingBottom="@dimen/dialog_button_padding_vertical"
         android:textSize="@dimen/dialog_button_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -45,15 +46,15 @@
     <com.willowtree.vocable.customviews.SettingsButton
         android:id="@+id/dialog_negative_button"
         style="@style/ConfirmationDialogButton"
-        android:textSize="@dimen/dialog_button_text_size"
         android:paddingStart="@dimen/dialog_button_padding_horizontal"
-        android:paddingEnd="@dimen/dialog_button_padding_horizontal"
         android:paddingTop="@dimen/dialog_button_padding_vertical"
+        android:paddingEnd="@dimen/dialog_button_padding_horizontal"
         android:paddingBottom="@dimen/dialog_button_padding_vertical"
-        app:layout_constraintHorizontal_bias="1.0"
+        android:textSize="@dimen/dialog_button_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/dialog_positive_button"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/dialog_message"
         tools:text="Cancel" />
 

--- a/app/src/main/res/layout/vocable_confirmation_dialog.xml
+++ b/app/src/main/res/layout/vocable_confirmation_dialog.xml
@@ -24,8 +24,9 @@
         style="@style/ConfirmationDialogText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/dialog_text_margin"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/dialog_title"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/dialog_title"
         tools:text="You're about to be taken outside of the app. You may lose head tracking control." />
 
@@ -40,10 +41,10 @@
     <com.willowtree.vocable.customviews.SettingsButton
         android:id="@+id/dialog_negative_button"
         style="@style/ConfirmationDialogButton"
-        app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/dialog_positive_button"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/dialog_message"
         tools:text="Cancel" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <!-- Edit Keyboard -->
     <string name="changes_saved">Changes Saved</string>
     <string name="category_created">Category Created</string>
+    <string name="duplicate_category">Sorry, this category name already exists. Please try a different name.</string>
 
     <!-- Timing and Sensitivity -->
     <string name="timing_sensitivity_title">Timing and Sensitivity</string>


### PR DESCRIPTION
Description: 
- Adds logic to prevent the user from entering a duplicate category name when adding a new category or editing an existing one
- Updates the confirmation dialog to show the duplicate name message if needed
