### PR TITLE
Delete phrase from custom category

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import com.willowtree.vocable.BaseViewModel
 import com.willowtree.vocable.presets.PresetsRepository
 import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryPhraseCrossRef
 import com.willowtree.vocable.room.Phrase
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import kotlinx.coroutines.launch
@@ -95,6 +96,29 @@ class EditCategoriesViewModel : BaseViewModel() {
             }
 
             refreshCategories()
+        }
+    }
+
+    fun deletePhraseFromCategory(phrase: Phrase, category: Category) {
+        backgroundScope.launch {
+            // Get a list of all of the phrases' cross refs (associations with categories)
+            val crossRefs = presetsRepository.getCrossRefsForPhraseIds(listOf(phrase.phraseId))
+
+            // Delete the cross ref with the given category
+            presetsRepository.deleteCrossRef(
+                CategoryPhraseCrossRef(
+                    category.categoryId,
+                    phrase.phraseId
+                )
+            )
+
+            // If the phrase is only associated with this category, delete it entirely
+            if (crossRefs.size == 1) {
+                presetsRepository.deletePhrase(phrase)
+            }
+
+            // Refresh phrase list
+            fetchCategoryPhrases(category)
         }
     }
 

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoryOptionsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoryOptionsFragment.kt
@@ -186,6 +186,7 @@ class EditCategoryOptionsFragment : BaseFragment<FragmentEditCategoryOptionsBind
     private fun handlePhrases(phrases: List<Phrase>) {
         binding.emptyPhrasesText.isVisible = phrases.isEmpty()
         binding.emptyAddPhraseButton.isVisible = phrases.isEmpty()
+        binding.editCategoryPhraseHolder.isVisible = phrases.isNotEmpty()
 
         if (phrases.isNotEmpty()) {
             with(binding.editCategoryPhraseHolder) {
@@ -230,7 +231,7 @@ class EditCategoryOptionsFragment : BaseFragment<FragmentEditCategoryOptionsBind
         override fun createFragment(position: Int): Fragment {
             val phrases = getItemsByPosition(position)
 
-            return CustomCategoryPhraseListFragment.newInstance(phrases)
+            return CustomCategoryPhraseListFragment.newInstance(phrases, args.category)
         }
 
     }

--- a/app/src/main/java/com/willowtree/vocable/settings/customcategories/CustomCategoryPhraseListFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/customcategories/CustomCategoryPhraseListFragment.kt
@@ -3,12 +3,17 @@ package com.willowtree.vocable.settings.customcategories
 import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.GridLayoutManager
 import com.willowtree.vocable.BaseFragment
+import com.willowtree.vocable.BaseViewModelFactory
 import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
 import com.willowtree.vocable.databinding.FragmentCustomCategoryPhraseListBinding
+import com.willowtree.vocable.room.Category
 import com.willowtree.vocable.room.Phrase
+import com.willowtree.vocable.settings.EditCategoriesViewModel
 import com.willowtree.vocable.settings.customcategories.adapter.CustomCategoryPhraseAdapter
 import com.willowtree.vocable.utils.ItemOffsetDecoration
 
@@ -16,20 +21,27 @@ class CustomCategoryPhraseListFragment : BaseFragment<FragmentCustomCategoryPhra
 
     companion object {
         private const val KEY_PHRASES = "KEY_PHRASES"
+        private const val KEY_CATEGORY = "KEY_CATEGORY"
 
-        fun newInstance(phrases: List<Phrase>): CustomCategoryPhraseListFragment {
+        fun newInstance(
+            phrases: List<Phrase>,
+            category: Category
+        ): CustomCategoryPhraseListFragment {
             return CustomCategoryPhraseListFragment().apply {
-                arguments = bundleOf(KEY_PHRASES to ArrayList(phrases))
+                arguments = bundleOf(KEY_PHRASES to ArrayList(phrases), KEY_CATEGORY to category)
             }
         }
     }
+
+    private lateinit var editCategoriesViewModel: EditCategoriesViewModel
+    private lateinit var category: Category
 
     private val onPhraseEdit = { phrase: Phrase ->
         // TODO: Handle editing the phrase
     }
 
     private val onPhraseDelete = { phrase: Phrase ->
-        // TODO: Handle deleting the phrase
+        showDeletePhraseDialog(phrase)
     }
 
     override val bindingInflater: BindingInflater<FragmentCustomCategoryPhraseListBinding> =
@@ -37,6 +49,10 @@ class CustomCategoryPhraseListFragment : BaseFragment<FragmentCustomCategoryPhra
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        arguments?.getParcelable<Category>(KEY_CATEGORY)?.let {
+            category = it
+        }
 
         val numColumns = resources.getInteger(R.integer.custom_category_phrase_columns)
         val numRows = resources.getInteger(R.integer.custom_category_phrase_rows)
@@ -57,6 +73,40 @@ class CustomCategoryPhraseListFragment : BaseFragment<FragmentCustomCategoryPhra
                 adapter = CustomCategoryPhraseAdapter(it, numRows, onPhraseEdit, onPhraseDelete)
             }
         }
+
+        editCategoriesViewModel = ViewModelProviders.of(
+            requireActivity(),
+            BaseViewModelFactory()
+        ).get(EditCategoriesViewModel::class.java)
+    }
+
+    private fun showDeletePhraseDialog(phrase: Phrase) {
+        with(binding.deleteConfirmation) {
+            dialogTitle.setText(R.string.are_you_sure)
+
+            dialogMessage.setText(R.string.delete_warning)
+
+            with(dialogPositiveButton) {
+                setText(R.string.delete)
+                action = {
+                    editCategoriesViewModel.deletePhraseFromCategory(phrase, category)
+                    toggleDialogVisibility(false)
+                }
+            }
+
+            with(dialogNegativeButton) {
+                setText(R.string.settings_dialog_cancel)
+                action = {
+                    toggleDialogVisibility(false)
+                }
+            }
+        }
+
+        toggleDialogVisibility(true)
+    }
+
+    private fun toggleDialogVisibility(visible: Boolean) {
+        binding.deleteConfirmation.root.isVisible = visible
     }
 
     override fun getAllViews(): List<View> = emptyList()

--- a/app/src/main/res/layout/fragment_custom_category_phrase_list.xml
+++ b/app/src/main/res/layout/fragment_custom_category_phrase_list.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/custom_category_phrase_holder"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/presets_parent"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/custom_category_phrase_holder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <include
+        android:id="@+id/delete_confirmation"
+        layout="@layout/vocable_confirmation_dialog"
+        android:layout_width="@dimen/dialog_width"
+        android:layout_height="@dimen/dialog_height"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
 
     <!-- Edit Sayings -->
     <string name="delete">Delete</string>
-    <string name="delete_warning">Deleted phrases cannot be recovered.</string>
+    <string name="delete_warning">Removed phrases cannot be recovered.</string>
     <string name="new_phrase_saved">New phrase saved</string>
     <string name="contiue_editing">Continue editing</string>
     <string name="discard">Discard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
 
     <!-- Edit Sayings -->
     <string name="delete">Delete</string>
-    <string name="delete_warning">Removed phrases cannot be recovered.</string>
+    <string name="delete_warning">Removed phrases cannot be restored.</string>
     <string name="new_phrase_saved">New phrase saved</string>
     <string name="contiue_editing">Continue editing</string>
     <string name="discard">Discard</string>


### PR DESCRIPTION
Description: 
- Adds logic to allow user to delete a phrase from a custom category directly from the list of phrases
- The phrase will be totally deleted from the database if it is only associated with the category currently being viewed. Otherwise it will remain in the database for its other categories
- [Figma link](https://www.figma.com/file/mNrwUygVhTmuWnKNHHkenR/Vocable-New?node-id=122%3A2791)
