### PR TITLE
Allow for editing of custom phrases

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoryOptionsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoryOptionsFragment.kt
@@ -186,6 +186,9 @@ class EditCategoryOptionsFragment : BaseFragment<FragmentEditCategoryOptionsBind
     private fun handlePhrases(phrases: List<Phrase>) {
         binding.emptyPhrasesText.isVisible = phrases.isEmpty()
         binding.emptyAddPhraseButton.isVisible = phrases.isEmpty()
+        binding.editCategoryPagerForwardButton.isVisible = phrases.isNotEmpty()
+        binding.editCategoryPagerBackButton.isVisible = phrases.isNotEmpty()
+        binding.editCategoryPageNumber.isVisible = phrases.isNotEmpty()
 
         if (phrases.isNotEmpty()) {
             with(binding.editCategoryPhraseHolder) {

--- a/app/src/main/java/com/willowtree/vocable/settings/customcategories/CustomCategoryPhraseListFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/customcategories/CustomCategoryPhraseListFragment.kt
@@ -3,12 +3,17 @@ package com.willowtree.vocable.settings.customcategories
 import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProviders
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import com.willowtree.vocable.BaseFragment
 import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
 import com.willowtree.vocable.databinding.FragmentCustomCategoryPhraseListBinding
 import com.willowtree.vocable.room.Phrase
+import com.willowtree.vocable.settings.EditCategoriesViewModel
+import com.willowtree.vocable.settings.EditCategoryOptionsFragmentDirections
 import com.willowtree.vocable.settings.customcategories.adapter.CustomCategoryPhraseAdapter
 import com.willowtree.vocable.utils.ItemOffsetDecoration
 
@@ -25,7 +30,8 @@ class CustomCategoryPhraseListFragment : BaseFragment<FragmentCustomCategoryPhra
     }
 
     private val onPhraseEdit = { phrase: Phrase ->
-        // TODO: Handle editing the phrase
+        val action = EditCategoryOptionsFragmentDirections.actionEditCategoryOptionsFragmentToEditPhrasesKeyboardFragment(phrase)
+        findNavController().navigate(action)
     }
 
     private val onPhraseDelete = { phrase: Phrase ->

--- a/app/src/main/res/navigation/settings_nav_graph.xml
+++ b/app/src/main/res/navigation/settings_nav_graph.xml
@@ -89,6 +89,9 @@
         <action
             android:id="@+id/action_editCategoryOptionsFragment_to_addPhraseKeyboardFragment"
             app:destination="@id/addPhraseKeyboardFragment" />
+        <action
+            android:id="@+id/action_editCategoryOptionsFragment_to_editPhrasesKeyboardFragment"
+            app:destination="@id/editPhrasesKeyboardFragment" />
     </fragment>
     <fragment
         android:id="@+id/addPhraseKeyboardFragment"


### PR DESCRIPTION
Description: 
Allows user to edit custom phrases that they have created.  It also fixes a small UI bug, where the arrows and page numbers would still appear in a category's empty state.

Closes #182 

- [ ] Acceptance Criteria satisfied
- [ ] Regression Testing
