### PR TITLE
Added some keyboard tests and one main screen test.

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/screens/KeyboardScreen.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/screens/KeyboardScreen.kt
@@ -1,0 +1,34 @@
+package com.willowtree.vocable.screens
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.NoMatchingViewException
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.willowtree.vocable.R
+import com.willowtree.vocable.utility.tap
+
+class KeyboardScreen {
+
+    // Keyboard
+    val keyboardInputText = onView(withId(R.id.keyboard_input))
+    val keyboardCont = onView(withId(R.id.keyboard_key_holder))
+    val keyboardSpaceButton = onView(withId(R.id.keyboard_space_button))
+    val keyboardBackspaceButton = onView(withId(R.id.keyboard_backspace_button))
+    val keyboardClearButton = onView(withId(R.id.keyboard_clear_button))
+    val keyboardPresetsButton = onView(withId(R.id.presets_button))
+
+    fun tapSeveralLetters(letters: String) {
+        val numLetters = letters.length
+
+        for (i in 1..numLetters) {
+            try {
+                if(letters[i-1] == ' ')
+                    keyboardSpaceButton.tap()
+                else
+                    onView(withText(letters[i - 1].toString().toUpperCase())).tap()
+            } catch (e: NoMatchingViewException) {
+                //do nothing if the character isn't one we support
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/willowtree/vocable/screens/MainScreen.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/screens/MainScreen.kt
@@ -82,4 +82,7 @@ class MainScreen {
     val phrasesForwardButton = onView(withId(R.id.phrases_forward_button))
     val phrasesPageNumber = onView(withId(R.id.phrases_page_number))
 
+    // Keyboard
+    val keyboardCont = onView(withId(R.id.keyboard_key_holder))
+
 }

--- a/app/src/androidTest/java/com/willowtree/vocable/tests/KeyboardTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/tests/KeyboardTest.kt
@@ -1,0 +1,80 @@
+package com.willowtree.vocable.tests
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.willowtree.vocable.screens.KeyboardScreen
+import com.willowtree.vocable.screens.MainScreen
+import com.willowtree.vocable.utility.assertElementExists
+import com.willowtree.vocable.utility.assertTextMatches
+import com.willowtree.vocable.utility.tap
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class KeyboardScreenTest : BaseTest() {
+
+    private val keyboardScreen = KeyboardScreen()
+    private val mainScreen = MainScreen()
+
+    @Test
+    fun verifyKeyboardButtonBringsUpKeyboard() {
+        navigateToKeyboard()
+
+        keyboardScreen.apply {
+            keyboardCont.assertElementExists()
+            keyboardInputText.assertTextMatches("Start typing…")
+        }
+    }
+
+    @Test
+    fun verifyPhraseAppearsWhenTyped() {
+        navigateToKeyboard()
+
+        keyboardScreen.apply {
+            tapSeveralLetters("CAT! cat cat")
+            keyboardInputText.assertTextMatches("Cat cat cat")
+        }
+    }
+
+    @Test
+    fun verifyBackspaceRemovesLetters() {
+        navigateToKeyboard()
+
+        keyboardScreen.apply {
+            tapSeveralLetters("Cats")
+            keyboardBackspaceButton.tap()
+            keyboardInputText.assertTextMatches("Cat")
+        }
+    }
+
+    @Test
+    fun verifyClearResetsInput() {
+        navigateToKeyboard()
+
+        keyboardScreen.apply {
+            tapSeveralLetters("Cats")
+            keyboardClearButton.tap()
+            keyboardInputText.assertTextMatches("Start typing…")
+        }
+    }
+
+    @Test
+    fun verifyPresetsButtonReturnsToHome() {
+        navigateToKeyboard()
+
+        keyboardScreen.apply {
+            keyboardPresetsButton.tap()
+        }
+
+        mainScreen.apply {
+            currentText.assertElementExists()
+        }
+
+    }
+
+    private fun navigateToKeyboard() {
+        mainScreen.apply {
+            keyboardNavitgationButton.tap()
+        }
+
+    }
+}

--- a/app/src/androidTest/java/com/willowtree/vocable/tests/MainScreenTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/tests/MainScreenTest.kt
@@ -3,7 +3,6 @@ package com.willowtree.vocable.tests
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.willowtree.vocable.screens.MainScreen
 import com.willowtree.vocable.utility.assertTextMatches
-import com.willowtree.vocable.utility.tap
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -13,18 +12,18 @@ class MainScreenTest : BaseTest() {
     private val mainScreen = MainScreen()
 
     @Test
-    fun verifyClickingPhraseUpdatesCurrentText() {
-        mainScreen.apply {
-            tapPhrase(defaultPhraseGeneral[0])
-            currentText.assertTextMatches(defaultPhraseGeneral[0])
-        }
-    }
-
-    @Test
     fun verifyDefaultTextAppears() {
         mainScreen.apply {
             val defaultText = "Select something below to speak."
             currentText.assertTextMatches(defaultText)
+        }
+    }
+
+    @Test
+    fun verifyClickingPhraseUpdatesCurrentText() {
+        mainScreen.apply {
+            tapPhrase(defaultPhraseGeneral[0])
+            currentText.assertTextMatches(defaultPhraseGeneral[0])
         }
     }
 
@@ -36,12 +35,18 @@ class MainScreenTest : BaseTest() {
     }
 
     @Test
-    fun testSelectingCategoryChangesPhrases() {
+    fun verifyDefaultSayingsInCategoriesExist() {
         mainScreen.apply {
-            mainScreen.scrollRightAndTapCurrentCategory(1)
-            verifyGivenPhrasesDisplay(mainScreen.defaultPhraseBasicNeeds)
+            scrollRightAndTapCurrentCategory(0)
+            verifyGivenPhrasesDisplay(defaultPhraseGeneral)
         }
     }
 
-
+    @Test
+    fun verifySelectingCategoryChangesPhrases() {
+        mainScreen.apply {
+            scrollRightAndTapCurrentCategory(1)
+            verifyGivenPhrasesDisplay(defaultPhraseBasicNeeds)
+        }
+    }
 }

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/ViewInteractionExt.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/ViewInteractionExt.kt
@@ -13,3 +13,7 @@ fun ViewInteraction.tap() {
 fun ViewInteraction.assertTextMatches(text: String) {
     check(ViewAssertions.matches(ViewMatchers.withText(CoreMatchers.containsString(text))))
 }
+
+fun ViewInteraction.assertElementExists() {
+    check(ViewAssertions.matches(CoreMatchers.not(ViewAssertions.doesNotExist())))
+}


### PR DESCRIPTION
**Added in Espresso tests**

- verifyDefaultSayingsInCategoriesExist: Main screen test to make sure that the General category is the first you see and holds the phrases we expect.
- Rearranged the MainScreenTest a bit to group the tests by functionality.
- Several tests for the keyboard screen testing the default view, that phrases show up, that you can remove letters, reset the phrase shown, and that you can navigate back to the home screen.

**Added in support for Espresso tests**
- Added in an assertElementExists function to ViewInteractionsExt.
- Added in the keyboard container to the MainScreen. 
- Described the keyboard screen.
- Added a function to let you type in one or more characters. It handles characters that we don't currently support.

**Known Issues**
-  I don't love the variable name I picked for the keyboard container but nothing else came to mind.
- Could add a little more error handling around the keyboard input function. 🤷‍♀️ 

**Next steps**
- This should set us up well to be able to work through custom categories and phrases with the keyboard input function.
- Another avenue to run down is Settings--there are currently no Settings tests which should be a pretty easy win.
