### PR TITLE
Add hover state to category switch

### DIFF
--- a/app/src/main/res/layout/custom_category_switch_item.xml
+++ b/app/src/main/res/layout/custom_category_switch_item.xml
@@ -12,7 +12,8 @@
     <com.willowtree.vocable.customviews.VocableConstraintLayout
         android:id="@+id/category_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="72dp"
+        android:background="@drawable/settings_group_background"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent">
 


### PR DESCRIPTION
Description: 
Add the orange hover outline to the switch layout when you add a phrase to a category

Fixes #331 

- [ ] Acceptance Criteria satisfied
- [ ] Regression Testing
