### PR TITLE
Reverting schema 4 to fix migration tests

### DIFF
--- a/app/schemas/com.willowtree.vocable.room.VocableDatabase/4.json
+++ b/app/schemas/com.willowtree.vocable.room.VocableDatabase/4.json
@@ -118,7 +118,7 @@
       },
       {
         "tableName": "CategoryPhraseCrossRef",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category_id` TEXT NOT NULL, `phrase_id` TEXT NOT NULL, `timestamp` INTEGER, PRIMARY KEY(`category_id`, `phrase_id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category_id` TEXT NOT NULL, `phrase_id` TEXT NOT NULL,  PRIMARY KEY(`category_id`, `phrase_id`))",
         "fields": [
           {
             "fieldPath": "categoryId",
@@ -131,12 +131,6 @@
             "columnName": "phrase_id",
             "affinity": "TEXT",
             "notNull": true
-          },
-          {
-            "fieldPath": "timestamp",
-            "columnName": "timestamp",
-            "affinity": "INTEGER",
-            "notNull": false
           }
         ],
         "primaryKey": {

--- a/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
@@ -1,3 +1,10 @@
+/**
+
+These tests confirm that users can successfully upgrade from older versions of Vocable to newer versions.
+All new migrations should have a test confirming the migration.
+
+**/
+
 package com.willowtree.vocable.room
 
 import androidx.room.testing.MigrationTestHelper


### PR DESCRIPTION
Schema 4 was overwritten with schema 5 which incorrectly gave it the timestamp column.  This PR removes that column, allowing the tests to proceed correctly.

I also added some comments as to the reason we have these tests in place.