### PR TITLE
Adding a 4to5 migration test.

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
@@ -218,11 +218,13 @@ class MigrationTest {
                 // Verify that new schema is as expected.
                 val categoryId = PresetCategories.USER_FAVORITES.id
                 val crossRefCursor =
-                    query("SELECT phrase_id FROM CategoryPhraseCrossRef WHERE category_id = '$categoryId'")
+                    query("SELECT * FROM CategoryPhraseCrossRef WHERE category_id = '$categoryId'")
                 val phrasesAdded = arrayListOf<String>()
                 val phraseIds =  mutableListOf<String>()
+                var timestamp: Long? = null
                 while (crossRefCursor.moveToNext()) {
                     val phraseId = crossRefCursor.getString(crossRefCursor.getColumnIndex("phrase_id"))
+                    timestamp = crossRefCursor.getLong(crossRefCursor.getColumnIndex("timestamp"))
                     phraseIds.add(phraseId)
                 }
                 crossRefCursor.close()
@@ -235,6 +237,7 @@ class MigrationTest {
                     phraseCursor.close()
 
                 Assert.assertTrue(phrasesAdded.contains(testPhraseV4))
+                Assert.assertEquals(0L, timestamp)
                close()
             }
     }


### PR DESCRIPTION
Added a test that looks at the migration from schema 4 to schema 5 (adding a timestamp.)

I based this off of one of the other tests in this file--it should create a phrase, migrate the database, then confirm the phrase is returned correctly.  This is my first go at writing a test like this, so feedback is much appreciated.