### PR TITLE
Remove button not appearing on categories

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoryOptionsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoryOptionsFragment.kt
@@ -39,7 +39,7 @@ class EditCategoryOptionsFragment : BaseFragment<FragmentEditCategoryOptionsBind
 
         category = args.category
         if (category.categoryId != PresetCategories.RECENTS.id) {
-            binding.removeCategoryButton.isInvisible = true
+            binding.removeCategoryButton.isInvisible = false
             binding.editOptionsButton.isInvisible = true
         }
 


### PR DESCRIPTION
Quick regression PR, remove category should be not show on recents but should show for other categories.
