### PR TITLE
Fixed bug where the starting category would not be selected initially

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
@@ -268,12 +268,15 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
                 }
                 setCurrentItem(targetPosition, false)
                 presetsViewModel.selectedCategory.removeObservers(viewLifecycleOwner)
-            })
-
-            presetsViewModel.selectedCategory.observe(viewLifecycleOwner, Observer { selectedCategory ->
-                recentsCategorySelected = selectedCategory.categoryId == PresetCategories.RECENTS.id
+                observeRecents()
             })
         }
+    }
+
+    private fun observeRecents() {
+        presetsViewModel.selectedCategory.observe(viewLifecycleOwner, Observer { selectedCategory ->
+            recentsCategorySelected = selectedCategory.categoryId == PresetCategories.RECENTS.id
+        })
     }
 
     private fun handlePhrases(phrases: List<Phrase>) {

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
@@ -3,7 +3,6 @@ package com.willowtree.vocable.presets
 import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.children
@@ -258,8 +257,7 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
                 targetPosition %= categoriesAdapter.numPages
             }
 
-
-            presetsViewModel.selectedCategory.value?.let { selectedCategory ->
+            presetsViewModel.selectedCategory.observe(viewLifecycleOwner, Observer{ selectedCategory ->
                 for (i in targetPosition until targetPosition + categoriesAdapter.numPages) {
                     val pageCategories = categoriesAdapter.getItemsByPosition(i)
 
@@ -268,13 +266,13 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
                         break
                     }
                 }
-            }
+                setCurrentItem(targetPosition, false)
+                presetsViewModel.selectedCategory.removeObservers(viewLifecycleOwner)
+            })
 
             presetsViewModel.selectedCategory.observe(viewLifecycleOwner, Observer { selectedCategory ->
                 recentsCategorySelected = selectedCategory.categoryId == PresetCategories.RECENTS.id
             })
-
-            setCurrentItem(targetPosition, false)
         }
     }
 


### PR DESCRIPTION
Description: 
Fixed a bug where the General category was not selected initially.
For some reason `presetsViewModel.selectedCategory.value`'s data was stuck in the mPendingData while the actual data was null. I made it set from an observer instead.
- [x] Acceptance Criteria satisfied
- [x] Regression Testing
