### PR TITLE
Bugfix/387 migration loses preferences

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,10 @@ dependencies {
     implementation 'com.google.ar:core:1.30.0'
     implementation 'com.google.ar.sceneform.ux:sceneform-ux:1.17.1'
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
+    def coroutines_version = "1.7.3"
+
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
 
     implementation 'io.github.inflationx:calligraphy3:3.1.1'
@@ -121,6 +123,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test:core:1.4.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     // Testing Navigation
     androidTestImplementation "androidx.navigation:navigation-testing:2.3.1"

--- a/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
@@ -7,13 +7,17 @@ All new migrations should have a test confirming the migration.
 
 package com.willowtree.vocable.room
 
+import androidx.room.Room
 import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.willowtree.vocable.presets.PresetCategories
 import com.willowtree.vocable.utils.VocableSharedPreferences
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
@@ -240,6 +244,85 @@ class MigrationTest {
                 Assert.assertEquals(0L, timestamp)
                close()
             }
+    }
+
+    @Test
+    fun migrate5to6() = runTest {
+        // Migration from a many-to-many relationship of categories and phrases
+        // to a one-to-many relationship of categories to phrases
+
+        helper.createDatabase(TEST_DB, 5).use {
+            //Create tables
+            it.execSQL(
+                "CREATE TABLE IF NOT EXISTS `Category` " +
+                        "(`category_id` TEXT NOT NULL, `creation_date` INTEGER NOT NULL, `is_user_generated` INTEGER NOT NULL, " +
+                        "`resource_id` INTEGER, `localized_name` TEXT, `hidden` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`category_id`))"
+            )
+
+            it.execSQL(
+                "CREATE TABLE IF NOT EXISTS `Phrase` (`phrase_id` TEXT NOT NULL, `creation_date` INTEGER NOT NULL, " +
+                        "`is_user_generated` INTEGER NOT NULL, `last_spoken_date` INTEGER NOT NULL, `resource_id` INTEGER, " +
+                        "`localized_utterance` TEXT, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`phrase_id`))"
+            )
+
+            it.execSQL(
+                "CREATE TABLE IF NOT EXISTS `CategoryPhraseCrossRef` (`category_id` TEXT NOT NULL, `phrase_id` TEXT NOT NULL, " +
+                        "`timestamp` INTEGER, PRIMARY KEY(`category_id`, `phrase_id`))"
+            )
+
+            // Add data
+            it.execSQL(
+                "INSERT INTO Category " +
+                        "(category_id, creation_date, is_user_generated, localized_name, hidden, sort_order) VALUES " +
+                        "('custom', 0, 0, '{\"english\":\"custom\"}', 0, 7)"
+            )
+
+            it.execSQL(
+                "INSERT INTO Phrase (phrase_id, creation_date, is_user_generated, last_spoken_date, localized_utterance, sort_order) VALUES " +
+                        "('1', 0, 1, 0, '{\"english\":\"hi\"}', 0)"
+            )
+            it.execSQL(
+                "INSERT INTO CategoryPhraseCrossRef (category_id, phrase_id) VALUES " +
+                        "('custom', '1')"
+            )
+        }
+
+        helper.runMigrationsAndValidate(TEST_DB, 6, true, VocableDatabaseMigrations.MIGRATION_5_6)
+
+        val db = Room.databaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            VocableDatabase::class.java,
+            TEST_DB
+        ).build()
+
+        val categories = db.categoryDao().getAllCategories()
+        assertEquals(
+            listOf(
+                Category(
+                    "custom",
+                    0L,
+                    null,
+                    mapOf("english" to "custom"),
+                    false,
+                    7
+                )
+            ), categories
+        )
+
+        val phrases = db.categoryDao().getCategoryWithPhrases("custom")?.phrases
+        assertEquals(
+            listOf(
+                Phrase(
+                    1L,
+                    "custom",
+                    0L,
+                    0L,
+                    mapOf("english" to "hi"),
+                    0
+                )
+            ), phrases
+        )
     }
 
 }

--- a/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
@@ -3,7 +3,7 @@
 These tests confirm that users can successfully upgrade from older versions of Vocable to newer versions.
 All new migrations should have a test confirming the migration.
 
-**/
+ **/
 
 package com.willowtree.vocable.room
 
@@ -118,17 +118,20 @@ class MigrationTest {
                 val crossRefCursor =
                     query("SELECT phrase_id FROM CategoryPhraseCrossRef WHERE category_id = '$categoryId'")
                 val myLocalizedSayings = arrayListOf<String>()
-                val phraseIds =  mutableListOf<String>()
+                val phraseIds = mutableListOf<String>()
                 while (crossRefCursor.moveToNext()) {
-                    val phraseId = crossRefCursor.getString(crossRefCursor.getColumnIndex("phrase_id"))
+                    val phraseId =
+                        crossRefCursor.getString(crossRefCursor.getColumnIndex("phrase_id"))
                     phraseIds.add(phraseId)
                 }
                 crossRefCursor.close()
 
                 phraseIds.forEach {
-                    val phraseCursor = query("SELECT localized_utterance FROM Phrase WHERE phrase_id = '$it'")
+                    val phraseCursor =
+                        query("SELECT localized_utterance FROM Phrase WHERE phrase_id = '$it'")
                     while (phraseCursor.moveToNext()) {
-                        val saying = phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
+                        val saying =
+                            phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
                         myLocalizedSayings.add(saying)
                     }
                     phraseCursor.close()
@@ -166,17 +169,20 @@ class MigrationTest {
                 val crossRefCursor =
                     query("SELECT phrase_id FROM CategoryPhraseCrossRef WHERE category_id = '$categoryId'")
                 val myLocalizedSayings = arrayListOf<String>()
-                val phraseIds =  mutableListOf<String>()
+                val phraseIds = mutableListOf<String>()
                 while (crossRefCursor.moveToNext()) {
-                    val phraseId = crossRefCursor.getString(crossRefCursor.getColumnIndex("phrase_id"))
+                    val phraseId =
+                        crossRefCursor.getString(crossRefCursor.getColumnIndex("phrase_id"))
                     phraseIds.add(phraseId)
                 }
                 crossRefCursor.close()
 
                 phraseIds.forEach {
-                    val phraseCursor = query("SELECT localized_utterance FROM Phrase WHERE phrase_id = '$it'")
+                    val phraseCursor =
+                        query("SELECT localized_utterance FROM Phrase WHERE phrase_id = '$it'")
                     while (phraseCursor.moveToNext()) {
-                        val saying = phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
+                        val saying =
+                            phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
                         myLocalizedSayings.add(saying)
                     }
                     phraseCursor.close()
@@ -224,25 +230,28 @@ class MigrationTest {
                 val crossRefCursor =
                     query("SELECT * FROM CategoryPhraseCrossRef WHERE category_id = '$categoryId'")
                 val phrasesAdded = arrayListOf<String>()
-                val phraseIds =  mutableListOf<String>()
+                val phraseIds = mutableListOf<String>()
                 var timestamp: Long? = null
                 while (crossRefCursor.moveToNext()) {
-                    val phraseId = crossRefCursor.getString(crossRefCursor.getColumnIndex("phrase_id"))
+                    val phraseId =
+                        crossRefCursor.getString(crossRefCursor.getColumnIndex("phrase_id"))
                     timestamp = crossRefCursor.getLong(crossRefCursor.getColumnIndex("timestamp"))
                     phraseIds.add(phraseId)
                 }
                 crossRefCursor.close()
 
-                    val phraseCursor = query("SELECT localized_utterance FROM Phrase WHERE phrase_id = '$phraseId'")
-                    while (phraseCursor.moveToNext()) {
-                        val saying = phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
-                        phrasesAdded.add(saying)
-                    }
-                    phraseCursor.close()
+                val phraseCursor =
+                    query("SELECT localized_utterance FROM Phrase WHERE phrase_id = '$phraseId'")
+                while (phraseCursor.moveToNext()) {
+                    val saying =
+                        phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
+                    phrasesAdded.add(saying)
+                }
+                phraseCursor.close()
 
                 Assert.assertTrue(phrasesAdded.contains(testPhraseV4))
                 Assert.assertEquals(0L, timestamp)
-               close()
+                close()
             }
     }
 

--- a/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
@@ -275,7 +275,12 @@ class MigrationTest {
             it.execSQL(
                 "INSERT INTO Category " +
                         "(category_id, creation_date, is_user_generated, localized_name, hidden, sort_order) VALUES " +
-                        "('custom', 0, 0, '{\"english\":\"custom\"}', 0, 7)"
+                        "('custom', 0, 1, '{\"english\":\"custom\"}', 0, 7)"
+            )
+            it.execSQL(
+                "INSERT INTO Category " +
+                        "(category_id, creation_date, is_user_generated, localized_name, hidden, sort_order) VALUES " +
+                        "('recents', 0, 0, '{\"english\":\"recents\"}', 0, 8)"
             )
 
             it.execSQL(
@@ -285,6 +290,12 @@ class MigrationTest {
             it.execSQL(
                 "INSERT INTO CategoryPhraseCrossRef (category_id, phrase_id) VALUES " +
                         "('custom', '1')"
+            )
+
+            // Add additional reference for a phrase included in multiple categories ie, how recents previously worked
+            it.execSQL(
+                "INSERT INTO CategoryPhraseCrossRef (category_id, phrase_id) VALUES " +
+                        "('recents', '1')"
             )
         }
 
@@ -306,11 +317,19 @@ class MigrationTest {
                     mapOf("english" to "custom"),
                     false,
                     7
+                ),
+                Category(
+                    "recents",
+                    0L,
+                    null,
+                    mapOf("english" to "recents"),
+                    false,
+                    8
                 )
             ), categories
         )
 
-        val phrases = db.categoryDao().getCategoryWithPhrases("custom")?.phrases
+        val customPhrases = db.categoryDao().getCategoryWithPhrases("custom")?.phrases
         assertEquals(
             listOf(
                 Phrase(
@@ -321,7 +340,7 @@ class MigrationTest {
                     mapOf("english" to "hi"),
                     0
                 )
-            ), phrases
+            ), customPhrases
         )
     }
 

--- a/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
@@ -339,6 +339,7 @@ class MigrationTest {
         )
 
         val customPhrases = db.categoryDao().getCategoryWithPhrases("custom")?.phrases
+        val recentPhrases = db.categoryDao().getCategoryWithPhrases("recents")?.phrases
         assertEquals(
             listOf(
                 Phrase(
@@ -350,6 +351,18 @@ class MigrationTest {
                     0
                 )
             ), customPhrases
+        )
+        assertEquals(
+            listOf(
+                Phrase(
+                    2L,
+                    "recents",
+                    0L,
+                    0L,
+                    mapOf("english" to "hi"),
+                    0
+                )
+            ), recentPhrases
         )
     }
 

--- a/app/src/main/java/com/willowtree/vocable/room/VocableDatabaseMigrations.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/VocableDatabaseMigrations.kt
@@ -73,7 +73,7 @@ object VocableDatabaseMigrations {
             val crossRefCursor =
                 database.query("SELECT phrase_id FROM CategoryPhraseCrossRef WHERE category_id = '$categoryId'")
             val myLocalizedSayings = LinkedHashSet<String>()
-            val phraseIds =  mutableListOf<String>()
+            val phraseIds = mutableListOf<String>()
             while (crossRefCursor.moveToNext()) {
                 val phraseId = crossRefCursor.getString(crossRefCursor.getColumnIndex("phrase_id"))
                 phraseIds.add(phraseId)
@@ -81,9 +81,11 @@ object VocableDatabaseMigrations {
             crossRefCursor.close()
 
             phraseIds.forEach {
-                val phraseCursor = database.query("SELECT localized_utterance FROM Phrase WHERE phrase_id = '$it'")
+                val phraseCursor =
+                    database.query("SELECT localized_utterance FROM Phrase WHERE phrase_id = '$it'")
                 while (phraseCursor.moveToNext()) {
-                    val saying = phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
+                    val saying =
+                        phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
                     myLocalizedSayings.add(saying)
                 }
                 phraseCursor.close()
@@ -161,9 +163,12 @@ object VocableDatabaseMigrations {
                     )
                 } ?: continue
                 val parentID = phraseToCategory.categoryId
-                val creationDate = phraseCursor.getLong(phraseCursor.getColumnIndex("creation_date"))
-                val lastSpokenDate = phraseCursor.getLong(phraseCursor.getColumnIndex("last_spoken_date"))
-                val localizedUtterance = phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
+                val creationDate =
+                    phraseCursor.getLong(phraseCursor.getColumnIndex("creation_date"))
+                val lastSpokenDate =
+                    phraseCursor.getLong(phraseCursor.getColumnIndex("last_spoken_date"))
+                val localizedUtterance =
+                    phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
                 val sortOrder = phraseCursor.getInt(phraseCursor.getColumnIndex("sort_order"))
 
                 database.execSQL("INSERT INTO Phrase_New (parent_category_id, creation_date, last_spoken_date, localized_utterance, sort_order) VALUES ('$parentID', $creationDate, $lastSpokenDate, '$localizedUtterance', $sortOrder)")
@@ -178,18 +183,23 @@ object VocableDatabaseMigrations {
                 database.query("SELECT * FROM Category")
             while (categoriesCursor.moveToNext()) {
 
-                val categoryID = categoriesCursor.getString(categoriesCursor.getColumnIndex("category_id"))
-                val creationDate = categoriesCursor.getInt(categoriesCursor.getColumnIndex("creation_date"))
-                val resourceID = categoriesCursor.getInt(categoriesCursor.getColumnIndex("resource_id")).let {
-                    if (it == 0) {
-                        null
-                    } else {
-                        it
+                val categoryID =
+                    categoriesCursor.getString(categoriesCursor.getColumnIndex("category_id"))
+                val creationDate =
+                    categoriesCursor.getInt(categoriesCursor.getColumnIndex("creation_date"))
+                val resourceID =
+                    categoriesCursor.getInt(categoriesCursor.getColumnIndex("resource_id")).let {
+                        if (it == 0) {
+                            null
+                        } else {
+                            it
+                        }
                     }
-                }
-                val localizedName = categoriesCursor.getString(categoriesCursor.getColumnIndex("localized_name"))
+                val localizedName =
+                    categoriesCursor.getString(categoriesCursor.getColumnIndex("localized_name"))
                 val hidden = categoriesCursor.getInt(categoriesCursor.getColumnIndex("hidden"))
-                val sortOrder = categoriesCursor.getInt(categoriesCursor.getColumnIndex("sort_order"))
+                val sortOrder =
+                    categoriesCursor.getInt(categoriesCursor.getColumnIndex("sort_order"))
                 database.execSQL("INSERT INTO Category_New (category_id, creation_date, localized_name, hidden, sort_order) VALUES ('$categoryID', '$creationDate', '$localizedName', '$hidden', '$sortOrder')")
             }
 

--- a/app/src/main/java/com/willowtree/vocable/room/VocableDatabaseMigrations.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/VocableDatabaseMigrations.kt
@@ -157,21 +157,22 @@ object VocableDatabaseMigrations {
             val phraseCursor =
                 database.query("SELECT * FROM Phrase WHERE is_user_generated=TRUE")
             while (phraseCursor.moveToNext()) {
-                val phraseToCategory = phraseToCategories.find {
+                phraseToCategories.filter {
                     it.phraseId == phraseCursor.getString(
                         phraseCursor.getColumnIndex("phrase_id")
                     )
-                } ?: continue
-                val parentID = phraseToCategory.categoryId
-                val creationDate =
-                    phraseCursor.getLong(phraseCursor.getColumnIndex("creation_date"))
-                val lastSpokenDate =
-                    phraseCursor.getLong(phraseCursor.getColumnIndex("last_spoken_date"))
-                val localizedUtterance =
-                    phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
-                val sortOrder = phraseCursor.getInt(phraseCursor.getColumnIndex("sort_order"))
+                }.forEach {
+                    val parentID = it.categoryId
+                    val creationDate =
+                        phraseCursor.getLong(phraseCursor.getColumnIndex("creation_date"))
+                    val lastSpokenDate =
+                        phraseCursor.getLong(phraseCursor.getColumnIndex("last_spoken_date"))
+                    val localizedUtterance =
+                        phraseCursor.getString(phraseCursor.getColumnIndex("localized_utterance"))
+                    val sortOrder = phraseCursor.getInt(phraseCursor.getColumnIndex("sort_order"))
 
-                database.execSQL("INSERT INTO Phrase_New (parent_category_id, creation_date, last_spoken_date, localized_utterance, sort_order) VALUES ('$parentID', $creationDate, $lastSpokenDate, '$localizedUtterance', $sortOrder)")
+                    database.execSQL("INSERT INTO Phrase_New (parent_category_id, creation_date, last_spoken_date, localized_utterance, sort_order) VALUES ('$parentID', $creationDate, $lastSpokenDate, '$localizedUtterance', $sortOrder)")
+                }
             }
             phraseCursor.close()
 


### PR DESCRIPTION
Description: 
Resolve bug where migration was losing phrases if they had been in recents. Fixes #387 

Recommend looking through by commit because the last commits reformat to match Studio defaults since I was sick of fighting them.

The fact that Recents is its own category still has problems, but they're outlined in #408 