### PR TITLE
Chore/408 make recents a query 1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,6 +116,8 @@ dependencies {
     androidTestUtil 'androidx.test:orchestrator:1.4.1'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
+    testImplementation "androidx.arch.core:core-testing:2.2.0"
     androidTestImplementation "androidx.room:room-testing:2.2.5"
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
@@ -319,7 +319,7 @@ class MigrationTest {
         val categories = db.categoryDao().getAllCategories()
         assertEquals(
             listOf(
-                Category(
+                CategoryDto(
                     "custom",
                     0L,
                     null,
@@ -327,7 +327,7 @@ class MigrationTest {
                     false,
                     7
                 ),
-                Category(
+                CategoryDto(
                     "recents",
                     0L,
                     null,

--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -14,5 +14,6 @@ object AppKoinModule {
         single { PresetsRepository(get()) }
         single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
         single { LocalizedResourceUtility() }
+        single { CategoriesUseCase(get()) }
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -3,8 +3,10 @@ package com.willowtree.vocable
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.willowtree.vocable.presets.PresetsRepository
+import com.willowtree.vocable.presets.PresetsViewModel
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import com.willowtree.vocable.utils.VocableSharedPreferences
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 object AppKoinModule {
@@ -15,5 +17,6 @@ object AppKoinModule {
         single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
         single { LocalizedResourceUtility() }
         single { CategoriesUseCase(get()) }
+        viewModel { PresetsViewModel(get(), get()) }
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -2,18 +2,20 @@ package com.willowtree.vocable
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.willowtree.vocable.presets.IPresetsRepository
 import com.willowtree.vocable.presets.PresetsRepository
 import com.willowtree.vocable.presets.PresetsViewModel
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import com.willowtree.vocable.utils.VocableSharedPreferences
 import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 object AppKoinModule {
 
     fun getModule() = module {
         single { VocableSharedPreferences() }
-        single { PresetsRepository(get()) }
+        single { PresetsRepository(get()) } bind IPresetsRepository::class
         single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
         single { LocalizedResourceUtility() }
         single { CategoriesUseCase(get()) }

--- a/app/src/main/java/com/willowtree/vocable/BaseViewModelFactory.kt
+++ b/app/src/main/java/com/willowtree/vocable/BaseViewModelFactory.kt
@@ -3,7 +3,6 @@ package com.willowtree.vocable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.willowtree.vocable.keyboard.KeyboardViewModel
-import com.willowtree.vocable.presets.PresetsViewModel
 import com.willowtree.vocable.settings.*
 import com.willowtree.vocable.splash.SplashViewModel
 
@@ -14,9 +13,6 @@ class BaseViewModelFactory : ViewModelProvider.Factory {
         when {
             modelClass.isAssignableFrom(SplashViewModel::class.java) -> {
                 return SplashViewModel() as T
-            }
-            modelClass.isAssignableFrom(PresetsViewModel::class.java) -> {
-                return PresetsViewModel() as T
             }
             modelClass.isAssignableFrom(SettingsViewModel::class.java) -> {
                 return SettingsViewModel() as T

--- a/app/src/main/java/com/willowtree/vocable/CategoriesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/CategoriesUseCase.kt
@@ -1,11 +1,11 @@
 package com.willowtree.vocable
 
-import com.willowtree.vocable.presets.PresetsRepository
+import com.willowtree.vocable.presets.IPresetsRepository
 import com.willowtree.vocable.room.CategoryDto
 import kotlinx.coroutines.flow.Flow
 
 class CategoriesUseCase(
-    private val presetsRepository: PresetsRepository
+    private val presetsRepository: IPresetsRepository
 ) {
 
     fun categories(): Flow<List<CategoryDto>> {

--- a/app/src/main/java/com/willowtree/vocable/CategoriesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/CategoriesUseCase.kt
@@ -1,0 +1,15 @@
+package com.willowtree.vocable
+
+import com.willowtree.vocable.presets.PresetsRepository
+import com.willowtree.vocable.room.CategoryDto
+import kotlinx.coroutines.flow.Flow
+
+class CategoriesUseCase(
+    private val presetsRepository: PresetsRepository
+) {
+
+    fun categories(): Flow<List<CategoryDto>> {
+        return presetsRepository.getAllCategoriesFlow()
+    }
+
+}

--- a/app/src/main/java/com/willowtree/vocable/presets/CategoriesFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/CategoriesFragment.kt
@@ -18,7 +18,7 @@ import com.willowtree.vocable.customviews.CategoryButton
 import com.willowtree.vocable.customviews.PointerListener
 import com.willowtree.vocable.databinding.CategoriesFragmentBinding
 import com.willowtree.vocable.databinding.CategoryButtonBinding
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import org.koin.android.ext.android.inject
 
@@ -27,7 +27,7 @@ class CategoriesFragment : BaseFragment<CategoriesFragmentBinding>() {
     companion object {
         const val KEY_CATEGORIES = "KEY_CATEGORIES"
 
-        fun newInstance(categories: List<Category>): CategoriesFragment {
+        fun newInstance(categories: List<CategoryDto>): CategoriesFragment {
             return CategoriesFragment().apply {
                 arguments = Bundle().apply {
                     putParcelableArrayList(KEY_CATEGORIES, ArrayList(categories))
@@ -52,14 +52,14 @@ class CategoriesFragment : BaseFragment<CategoriesFragmentBinding>() {
         maxCategories = resources.getInteger(R.integer.max_categories)
         val isTablet = resources.getBoolean(R.bool.is_tablet)
 
-        val categories = arguments?.getParcelableArrayList<Category>(KEY_CATEGORIES)
+        val categories = arguments?.getParcelableArrayList<CategoryDto>(KEY_CATEGORIES)
         categories?.forEachIndexed { index, category ->
             val categoryButton =
                 CategoryButtonBinding.inflate(inflater, binding.categoryButtonContainer, false)
             with(categoryButton.root) {
                 tag = category
                 action = {
-                    viewModel.onCategorySelected(category)
+                    viewModel.onCategorySelected(category.categoryId)
 
                 }
                 text = localizedResourceUtility.getTextFromCategory(category)
@@ -112,11 +112,11 @@ class CategoriesFragment : BaseFragment<CategoriesFragmentBinding>() {
     }
 
     private fun subscribeToViewModel() {
-        viewModel.selectedCategory.observe(viewLifecycleOwner, Observer { category ->
+        viewModel.selectedCategoryLiveData.observe(viewLifecycleOwner, Observer { category ->
             category?.let {
                 binding.categoryButtonContainer.children.forEach {
                     if (it is CategoryButton) {
-                        it.isSelected = (it.tag as? Category)?.categoryId == category.categoryId
+                        it.isSelected = (it.tag as? CategoryDto)?.categoryId == category.categoryId
                     }
                 }
             }

--- a/app/src/main/java/com/willowtree/vocable/presets/CategoriesFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/CategoriesFragment.kt
@@ -9,9 +9,7 @@ import androidx.core.view.children
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import com.willowtree.vocable.BaseFragment
-import com.willowtree.vocable.BaseViewModelFactory
 import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
 import com.willowtree.vocable.customviews.CategoryButton
@@ -21,6 +19,8 @@ import com.willowtree.vocable.databinding.CategoryButtonBinding
 import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ViewModelOwner
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class CategoriesFragment : BaseFragment<CategoriesFragmentBinding>() {
 
@@ -38,7 +38,9 @@ class CategoriesFragment : BaseFragment<CategoriesFragmentBinding>() {
 
     override val bindingInflater: BindingInflater<CategoriesFragmentBinding> = CategoriesFragmentBinding::inflate
 
-    private lateinit var viewModel: PresetsViewModel
+    private val viewModel: PresetsViewModel by viewModel(owner = {
+        ViewModelOwner.from(requireActivity())
+    })
     private val allViews = mutableListOf<View>()
     private var maxCategories = 1
     private val localizedResourceUtility: LocalizedResourceUtility by inject()
@@ -86,10 +88,6 @@ class CategoriesFragment : BaseFragment<CategoriesFragmentBinding>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel = ViewModelProviders.of(
-            requireActivity(),
-            BaseViewModelFactory()
-        ).get(PresetsViewModel::class.java)
         subscribeToViewModel()
     }
 

--- a/app/src/main/java/com/willowtree/vocable/presets/IPresetsRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/IPresetsRepository.kt
@@ -1,9 +1,12 @@
 package com.willowtree.vocable.presets
 
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
+import kotlinx.coroutines.flow.Flow
 
 //TODO: PK - Rename this once we make the jump to rename [PresetsRepository] -> "RoomPresetsRepository"
 interface IPresetsRepository {
     suspend fun getPhrasesForCategory(categoryId: String): List<Phrase>
     suspend fun addPhraseToRecents(phrase: Phrase)
+    fun getAllCategoriesFlow(): Flow<List<CategoryDto>>
 }

--- a/app/src/main/java/com/willowtree/vocable/presets/IPresetsRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/IPresetsRepository.kt
@@ -1,0 +1,9 @@
+package com.willowtree.vocable.presets
+
+import com.willowtree.vocable.room.Phrase
+
+//TODO: PK - Rename this once we make the jump to rename [PresetsRepository] -> "RoomPresetsRepository"
+interface IPresetsRepository {
+    suspend fun getPhrasesForCategory(categoryId: String): List<Phrase>
+    suspend fun addPhraseToRecents(phrase: Phrase)
+}

--- a/app/src/main/java/com/willowtree/vocable/presets/PhrasesFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PhrasesFragment.kt
@@ -4,19 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.GridLayoutManager
 import com.willowtree.vocable.BaseFragment
-import com.willowtree.vocable.BaseViewModelFactory
 import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
 import com.willowtree.vocable.databinding.FragmentPhrasesBinding
 import com.willowtree.vocable.presets.adapter.PhraseAdapter
 import com.willowtree.vocable.room.Phrase
 import com.willowtree.vocable.utils.ItemOffsetDecoration
+import org.koin.androidx.viewmodel.ViewModelOwner
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class PhrasesFragment : BaseFragment<FragmentPhrasesBinding>() {
-    private lateinit var presetsViewModel: PresetsViewModel
+    private val presetsViewModel: PresetsViewModel by viewModel(owner = {
+        ViewModelOwner.from(requireActivity())
+    })
 
     companion object {
         private const val KEY_PHRASES = "KEY_PHRASES"
@@ -37,14 +39,8 @@ class PhrasesFragment : BaseFragment<FragmentPhrasesBinding>() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         super.onCreateView(inflater, container, savedInstanceState)
-
-        presetsViewModel =
-            ViewModelProviders.of(
-                requireActivity(),
-                BaseViewModelFactory()
-            ).get(PresetsViewModel::class.java)
 
         val numColumns = resources.getInteger(R.integer.phrases_columns)
         val numRows = resources.getInteger(R.integer.phrases_rows)

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
@@ -10,7 +10,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
@@ -22,6 +21,8 @@ import com.willowtree.vocable.room.Phrase
 import com.willowtree.vocable.utils.SpokenText
 import com.willowtree.vocable.utils.VocableFragmentStateAdapter
 import com.willowtree.vocable.utils.VocableTextToSpeech
+import org.koin.androidx.viewmodel.ViewModelOwner
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
 
@@ -34,7 +35,9 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
     private var isPortraitMode = true
     private var isTabletMode = false
 
-    private lateinit var presetsViewModel: PresetsViewModel
+    private val presetsViewModel: PresetsViewModel by viewModel(owner = {
+        ViewModelOwner.from(requireActivity())
+    })
     private lateinit var categoriesAdapter: CategoriesPagerAdapter
     private lateinit var phrasesAdapter: PhrasesPagerAdapter
 
@@ -187,11 +190,6 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
 
         SpokenText.postValue(null)
 
-        presetsViewModel =
-            ViewModelProviders.of(
-                requireActivity(),
-                BaseViewModelFactory()
-            ).get(PresetsViewModel::class.java)
         subscribeToViewModel()
     }
 

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsRepository.kt
@@ -10,7 +10,7 @@ import org.koin.core.component.get
 import java.util.Calendar
 import java.util.Locale
 
-class PresetsRepository(val context: Context) : KoinComponent {
+class PresetsRepository(val context: Context) : KoinComponent, IPresetsRepository {
 
     private val database = VocableDatabase.getVocableDatabase(context)
 
@@ -26,7 +26,7 @@ class PresetsRepository(val context: Context) : KoinComponent {
         return database.categoryDao().getAllCategories()
     }
 
-    suspend fun getPhrasesForCategory(categoryId: String): List<Phrase> {
+    override suspend fun getPhrasesForCategory(categoryId: String): List<Phrase> {
         return database.categoryDao().getCategoryWithPhrases(categoryId)?.phrases ?: listOf()
     }
 
@@ -34,7 +34,7 @@ class PresetsRepository(val context: Context) : KoinComponent {
         database.phraseDao().insertPhrase(phrase)
     }
 
-    suspend fun addPhraseToRecents(phrase: Phrase) {
+    override suspend fun addPhraseToRecents(phrase: Phrase) {
 
         val phrases = getPhrasesForCategory(
             PresetCategories.RECENTS.id

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsRepository.kt
@@ -18,7 +18,7 @@ class PresetsRepository(val context: Context) : KoinComponent, IPresetsRepositor
         return database.categoryDao().getAllCategories()
     }
 
-    fun getAllCategoriesFlow(): Flow<List<CategoryDto>> {
+    override fun getAllCategoriesFlow(): Flow<List<CategoryDto>> {
         return database.categoryDao().getAllCategoriesFlow()
     }
 

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsRepository.kt
@@ -1,22 +1,28 @@
 package com.willowtree.vocable.presets
 
 import android.content.Context
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import com.willowtree.vocable.room.VocableDatabase
+import kotlinx.coroutines.flow.Flow
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
-import java.util.*
+import java.util.Calendar
+import java.util.Locale
 
 class PresetsRepository(val context: Context) : KoinComponent {
 
     private val database = VocableDatabase.getVocableDatabase(context)
 
-    suspend fun getAllCategories(): List<Category> {
+    suspend fun getAllCategories(): List<CategoryDto> {
         return database.categoryDao().getAllCategories()
     }
 
-    suspend fun getUserGeneratedCategories(): List<Category> {
+    fun getAllCategoriesFlow(): Flow<List<CategoryDto>> {
+        return database.categoryDao().getAllCategoriesFlow()
+    }
+
+    suspend fun getUserGeneratedCategories(): List<CategoryDto> {
         return database.categoryDao().getAllCategories()
     }
 
@@ -70,11 +76,11 @@ class PresetsRepository(val context: Context) : KoinComponent {
         }
     }
 
-    suspend fun addCategory(category: Category) {
+    suspend fun addCategory(category: CategoryDto) {
         database.categoryDao().insertCategory(category)
     }
 
-    suspend fun populateCategories(categories: List<Category>) {
+    suspend fun populateCategories(categories: List<CategoryDto>) {
         database.categoryDao().insertCategories(*categories.toTypedArray())
     }
 
@@ -90,7 +96,7 @@ class PresetsRepository(val context: Context) : KoinComponent {
         database.phraseDao().deletePhrases(*phrases.toTypedArray())
     }
 
-    suspend fun deleteCategory(category: Category) {
+    suspend fun deleteCategory(category: CategoryDto) {
         database.categoryDao().deleteCategory(category)
     }
 
@@ -98,15 +104,15 @@ class PresetsRepository(val context: Context) : KoinComponent {
         database.phraseDao().updatePhrase(phrase)
     }
 
-    suspend fun updateCategory(category: Category) {
+    suspend fun updateCategory(category: CategoryDto) {
         database.categoryDao().updateCategory(category)
     }
 
-    suspend fun updateCategories(categories: List<Category>) {
+    suspend fun updateCategories(categories: List<CategoryDto>) {
         database.categoryDao().updateCategories(*categories.toTypedArray())
     }
 
-    suspend fun getCategoryById(categoryId: String): Category {
+    suspend fun getCategoryById(categoryId: String): CategoryDto {
         return database.categoryDao().getCategoryById(categoryId)
     }
 
@@ -137,7 +143,7 @@ class PresetsRepository(val context: Context) : KoinComponent {
                 populatePhrases(phraseObjects)
             }
             database.categoryDao().insertCategories(
-                Category(
+                CategoryDto(
                     presetCategory.id,
                     System.currentTimeMillis(),
                     presetCategory.getNameId(),

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
@@ -3,7 +3,7 @@ package com.willowtree.vocable.presets
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.willowtree.vocable.BaseViewModel
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import kotlinx.coroutines.launch
 import org.koin.core.component.inject
@@ -12,11 +12,11 @@ class PresetsViewModel : BaseViewModel() {
 
     private val presetsRepository: PresetsRepository by inject()
 
-    private val liveCategoryList = MutableLiveData<List<Category>>()
-    val categoryList: LiveData<List<Category>> = liveCategoryList
+    private val liveCategoryList = MutableLiveData<List<CategoryDto>>()
+    val categoryList: LiveData<List<CategoryDto>> = liveCategoryList
 
-    private val liveSelectedCategory = MutableLiveData<Category>()
-    val selectedCategory: LiveData<Category> = liveSelectedCategory
+    private val liveSelectedCategory = MutableLiveData<CategoryDto>()
+    val selectedCategory: LiveData<CategoryDto> = liveSelectedCategory
 
     private val liveCurrentPhrases = MutableLiveData<List<Phrase?>>()
     val currentPhrases: LiveData<List<Phrase?>> = liveCurrentPhrases
@@ -42,7 +42,7 @@ class PresetsViewModel : BaseViewModel() {
         }
     }
 
-    fun onCategorySelected(category: Category) {
+    fun onCategorySelected(category: CategoryDto) {
         liveSelectedCategory.postValue(category)
 
         backgroundScope.launch {

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class PresetsViewModel(
-    private val presetsRepository: PresetsRepository,
+    private val presetsRepository: IPresetsRepository,
     categoriesUseCase: CategoriesUseCase
 ) : ViewModel() {
 

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
@@ -2,9 +2,9 @@ package com.willowtree.vocable.presets
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.willowtree.vocable.BaseViewModel
 import com.willowtree.vocable.CategoriesUseCase
 import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
@@ -17,12 +17,11 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import org.koin.core.component.inject
 
-class PresetsViewModel : BaseViewModel() {
-
-    private val presetsRepository: PresetsRepository by inject()
-    private val categoriesUseCase: CategoriesUseCase by inject()
+class PresetsViewModel(
+    private val presetsRepository: PresetsRepository,
+    categoriesUseCase: CategoriesUseCase
+) : ViewModel() {
 
     val categoryList: LiveData<List<CategoryDto>> = categoriesUseCase.categories().asLiveData()
 
@@ -66,7 +65,7 @@ class PresetsViewModel : BaseViewModel() {
     }
 
     fun addToRecents(phrase: Phrase) {
-        backgroundScope.launch {
+        viewModelScope.launch {
             presetsRepository.addPhraseToRecents(phrase)
         }
     }

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
@@ -2,74 +2,67 @@ package com.willowtree.vocable.presets
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.BaseViewModel
+import com.willowtree.vocable.CategoriesUseCase
 import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.koin.core.component.inject
 
 class PresetsViewModel : BaseViewModel() {
 
     private val presetsRepository: PresetsRepository by inject()
+    private val categoriesUseCase: CategoriesUseCase by inject()
 
-    private val liveCategoryList = MutableLiveData<List<CategoryDto>>()
-    val categoryList: LiveData<List<CategoryDto>> = liveCategoryList
+    val categoryList: LiveData<List<CategoryDto>> = categoriesUseCase.categories().asLiveData()
 
-    private val liveSelectedCategory = MutableLiveData<CategoryDto>()
-    val selectedCategory: LiveData<CategoryDto> = liveSelectedCategory
+    // Will only ever be null immediately on init
+    private val liveSelectedCategoryId = MutableStateFlow<String?>(null)
+    val selectedCategory: StateFlow<CategoryDto?> = combine(
+        categoriesUseCase.categories(),
+        liveSelectedCategoryId
+    ) { categories, selectedId ->
+        categories.find { it.categoryId == selectedId }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), null)
+    val selectedCategoryLiveData: LiveData<CategoryDto?> = selectedCategory.asLiveData()
 
-    private val liveCurrentPhrases = MutableLiveData<List<Phrase?>>()
-    val currentPhrases: LiveData<List<Phrase?>> = liveCurrentPhrases
+    val currentPhrases: LiveData<List<Phrase?>> = liveSelectedCategoryId.map { categoryId ->
+        if (categoryId == null) return@map emptyList<Phrase>()
+        val phrases: MutableList<Phrase?> = if (categoryId == PresetCategories.RECENTS.id) {
+            presetsRepository.getPhrasesForCategory(categoryId)
+                .sortedBy { it.lastSpokenDate }.reversed().toMutableList()
+        } else {
+            presetsRepository.getPhrasesForCategory(categoryId)
+                .sortedBy { it.sortOrder }.toMutableList()
+        }
+        //Add null to end of normal non empty category phrase list for the "+ Add Phrase" button
+        if (categoryId != PresetCategories.RECENTS.id && categoryId != PresetCategories.USER_KEYPAD.id && phrases.isNotEmpty()) {
+            phrases.add(null)
+        }
+        return@map phrases
+    }.asLiveData()
 
     private val liveNavToAddPhrase = MutableLiveData<Boolean>()
     val navToAddPhrase: LiveData<Boolean> = liveNavToAddPhrase
 
     init {
-        populateCategories()
-    }
-
-    fun populateCategories() {
-        backgroundScope.launch {
-            val categories = presetsRepository.getAllCategories().filter { !it.hidden }
-            liveCategoryList.postValue(categories)
-            val currentCategory = if (categories.contains(liveSelectedCategory.value) && liveSelectedCategory.value != null) {
-                liveSelectedCategory.value ?: categories.first()
-            } else {
-                categories.first()
-            }
-
-            onCategorySelected(currentCategory)
+        viewModelScope.launch {
+            liveSelectedCategoryId.update { categoriesUseCase.categories().first().first().categoryId }
         }
     }
 
-    fun onCategorySelected(category: CategoryDto) {
-        liveSelectedCategory.postValue(category)
-
-        backgroundScope.launch {
-            val catId = presetsRepository.getCategoryById(category.categoryId)
-
-            // make sure the category wasn't deleted before getting its phrases
-            if (catId != null) {
-
-                // if the selected category was the Recents category, we need to invert the sort so
-                // the most recently added phrases are at the top
-                val phrases: MutableList<Phrase?> = if (catId.categoryId == PresetCategories.RECENTS.id) {
-                    presetsRepository.getPhrasesForCategory(category.categoryId)
-                        .sortedBy { it.lastSpokenDate }.reversed().toMutableList()
-                } else {
-                    presetsRepository.getPhrasesForCategory(category.categoryId)
-                        .sortedBy { it.sortOrder }.toMutableList()
-                }
-                //Add null to end of normal non empty category phrase list for the "+ Add Phrase" button
-                if (catId.categoryId != PresetCategories.RECENTS.id && catId.categoryId != PresetCategories.USER_KEYPAD.id && phrases.isNotEmpty()) {
-                    phrases.add(null)
-                }
-                liveCurrentPhrases.postValue(phrases)
-            } else { // if the category has been deleted, select the first available category to show
-                val categories = presetsRepository.getAllCategories().filter { !it.hidden }
-                onCategorySelected(categories[0])
-            }
-        }
+    fun onCategorySelected(categoryId: String) {
+        liveSelectedCategoryId.update { categoryId }
     }
 
     fun addToRecents(phrase: Phrase) {

--- a/app/src/main/java/com/willowtree/vocable/presets/adapter/CustomCategoryAdapter.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/adapter/CustomCategoryAdapter.kt
@@ -7,15 +7,15 @@ import androidx.core.view.isInvisible
 import androidx.recyclerview.widget.RecyclerView
 import com.willowtree.vocable.R
 import com.willowtree.vocable.databinding.CustomCategorySwitchItemBinding
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class CustomCategoryAdapter(
-    private var categories: Map<Category, Boolean>,
+    private var categories: Map<CategoryDto, Boolean>,
     private val numRows: Int,
-    private val onCategoryToggle: (Category, Boolean) -> Unit
+    private val onCategoryToggle: (CategoryDto, Boolean) -> Unit
 ) : RecyclerView.Adapter<CustomCategoryAdapter.CustomCategoryViewHolder>(), KoinComponent {
 
     private val localizedResourceUtility: LocalizedResourceUtility by inject()
@@ -26,7 +26,7 @@ class CustomCategoryAdapter(
         private val binding: CustomCategorySwitchItemBinding =
             CustomCategorySwitchItemBinding.bind(itemView)
 
-        fun bind(category: Category, isChecked: Boolean, onCategoryToggle: (Category, Boolean) -> Unit) {
+        fun bind(category: CategoryDto, isChecked: Boolean, onCategoryToggle: (CategoryDto, Boolean) -> Unit) {
             binding.categoryText.text = localizedResourceUtility.getTextFromCategory(category)
 
             binding.categoryContainer.action = { binding.toggleSwitch.isChecked = !binding.toggleSwitch.isChecked }
@@ -62,7 +62,7 @@ class CustomCategoryAdapter(
         return _minHeight ?: 0
     }
 
-    fun setMap(map: Map<Category, Boolean>) {
+    fun setMap(map: Map<CategoryDto, Boolean>) {
         this.categories = map
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/willowtree/vocable/room/CategoryDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/CategoryDao.kt
@@ -1,30 +1,34 @@
 package com.willowtree.vocable.room
 
 import androidx.room.*
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CategoryDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertCategories(vararg categories: Category)
+    suspend fun insertCategories(vararg categories: CategoryDto)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertCategory(category: Category)
+    suspend fun insertCategory(category: CategoryDto)
 
     @Query("SELECT * FROM Category WHERE category_id != 'preset_user_favorites' ORDER BY sort_order ASC")
-    suspend fun getAllCategories(): List<Category>
+    suspend fun getAllCategories(): List<CategoryDto>
+
+    @Query("SELECT * FROM Category WHERE category_id != 'preset_user_favorites' ORDER BY sort_order ASC")
+    fun getAllCategoriesFlow(): Flow<List<CategoryDto>>
 
     @Query("SELECT * FROM Category WHERE category_id = :categoryId")
-    suspend fun getCategoryById(categoryId: String): Category
+    suspend fun getCategoryById(categoryId: String): CategoryDto
 
     @Delete
-    suspend fun deleteCategory(category: Category)
+    suspend fun deleteCategory(category: CategoryDto)
 
     @Update
-    suspend fun updateCategory(category: Category)
+    suspend fun updateCategory(category: CategoryDto)
 
     @Update
-    suspend fun updateCategories(vararg categories: Category)
+    suspend fun updateCategories(vararg categories: CategoryDto)
 
     @Query("SELECT COUNT(*) FROM Category WHERE NOT hidden")
     suspend fun getNumberOfShownCategories(): Int

--- a/app/src/main/java/com/willowtree/vocable/room/CategoryDto.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/CategoryDto.kt
@@ -6,9 +6,9 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import kotlinx.parcelize.Parcelize
 
-@Entity
+@Entity(tableName = "Category")
 @Parcelize
-data class Category(
+data class CategoryDto(
     @PrimaryKey @ColumnInfo(name = "category_id") val categoryId: String,
     @ColumnInfo(name = "creation_date") val creationDate: Long,
     @ColumnInfo(name = "resource_id") val resourceId: Int?,

--- a/app/src/main/java/com/willowtree/vocable/room/CategoryWithPhrases.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/CategoryWithPhrases.kt
@@ -1,11 +1,10 @@
 package com.willowtree.vocable.room
 
 import androidx.room.Embedded
-import androidx.room.Junction
 import androidx.room.Relation
 
 data class CategoryWithPhrases(
-    @Embedded val category: Category,
+    @Embedded val category: CategoryDto,
     @Relation(
         parentColumn = "category_id",
         entityColumn = "parent_category_id"

--- a/app/src/main/java/com/willowtree/vocable/room/VocableDatabase.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/VocableDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 
-@Database(entities = [Category::class, Phrase::class], version = 6)
+@Database(entities = [CategoryDto::class, Phrase::class], version = 6)
 @TypeConverters(Converters::class)
 abstract class VocableDatabase : RoomDatabase() {
 

--- a/app/src/main/java/com/willowtree/vocable/settings/AddPhraseKeyboardFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/AddPhraseKeyboardFragment.kt
@@ -1,21 +1,17 @@
 package com.willowtree.vocable.settings
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import android.widget.TextView
 import android.widget.Toast
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.willowtree.vocable.BaseViewModelFactory
 import com.willowtree.vocable.R
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 
 class AddPhraseKeyboardFragment : EditKeyboardFragment() {
@@ -34,7 +30,7 @@ class AddPhraseKeyboardFragment : EditKeyboardFragment() {
 
     private lateinit var viewModel: AddPhraseViewModel
     private val args: AddPhraseKeyboardFragmentArgs by navArgs()
-    private lateinit var category: Category
+    private lateinit var category: CategoryDto
     private var savedPhrase = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.willowtree.vocable.BaseViewModel
 import com.willowtree.vocable.presets.PresetsRepository
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -27,7 +27,7 @@ class AddUpdateCategoryViewModel : BaseViewModel() {
     private val liveShowDuplicateCategoryMessage = MutableLiveData<Boolean>()
     val showDuplicateCategoryMessage: LiveData<Boolean> = liveShowDuplicateCategoryMessage
 
-    private var allCategories = listOf<Category>()
+    private var allCategories = listOf<CategoryDto>()
 
     init {
         populateAllCategories()
@@ -88,7 +88,7 @@ class AddUpdateCategoryViewModel : BaseViewModel() {
                 it.sortOrder++
             }
 
-            val newCategory = Category(
+            val newCategory = CategoryDto(
                 UUID.randomUUID().toString(),
                 System.currentTimeMillis(),
                 null,

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesFragment.kt
@@ -10,7 +10,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.willowtree.vocable.*
 import com.willowtree.vocable.databinding.FragmentEditCategoriesBinding
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.utils.VocableFragmentStateAdapter
 import kotlin.math.min
 
@@ -141,9 +141,9 @@ class EditCategoriesFragment : BaseFragment<FragmentEditCategoriesBinding>() {
     }
 
     inner class CategoriesPagerAdapter(fm: FragmentManager) :
-        VocableFragmentStateAdapter<Category>(fm, viewLifecycleOwner.lifecycle) {
+        VocableFragmentStateAdapter<CategoryDto>(fm, viewLifecycleOwner.lifecycle) {
 
-        override fun setItems(items: List<Category>) {
+        override fun setItems(items: List<CategoryDto>) {
             super.setItems(items)
             setPagingButtonsEnabled(categoriesAdapter.numPages > 1)
         }

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesKeyboardFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesKeyboardFragment.kt
@@ -13,7 +13,7 @@ import com.willowtree.vocable.BaseViewModelFactory
 import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
 import com.willowtree.vocable.databinding.FragmentEditKeyboardBinding
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 
 class EditCategoriesKeyboardFragment : EditKeyboardFragment() {
 
@@ -24,7 +24,7 @@ class EditCategoriesKeyboardFragment : EditKeyboardFragment() {
 
     private val args: EditCategoriesKeyboardFragmentArgs by navArgs()
 
-    private var currentCategory: Category? = null
+    private var currentCategory: CategoryDto? = null
     private var currentCategoryText: String? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesListFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesListFragment.kt
@@ -13,7 +13,7 @@ import com.willowtree.vocable.R
 import com.willowtree.vocable.customviews.NoSayTextButton
 import com.willowtree.vocable.databinding.CategoryEditButtonBinding
 import com.willowtree.vocable.databinding.FragmentEditCategoriesListBinding
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import org.koin.android.ext.android.inject
 
@@ -126,7 +126,7 @@ class EditCategoriesListFragment : BaseFragment<FragmentEditCategoriesListBindin
 
     private fun bindCategoryEditButton(
         editButtonBinding: CategoryEditButtonBinding,
-        category: Category,
+        category: CategoryDto,
         overallIndex: Int,
         size: Int
     ) {

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import com.willowtree.vocable.BaseViewModel
 import com.willowtree.vocable.presets.PresetCategories
 import com.willowtree.vocable.presets.PresetsRepository
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import kotlinx.coroutines.launch
@@ -15,11 +15,11 @@ class EditCategoriesViewModel : BaseViewModel() {
 
     private val presetsRepository: PresetsRepository by inject()
 
-    private val liveOrderCategoryList = MutableLiveData<List<Category>>()
-    val orderCategoryList: LiveData<List<Category>> = liveOrderCategoryList
+    private val liveOrderCategoryList = MutableLiveData<List<CategoryDto>>()
+    val orderCategoryList: LiveData<List<CategoryDto>> = liveOrderCategoryList
 
-    private val liveAddRemoveCategoryList = MutableLiveData<List<Category>>()
-    val addRemoveCategoryList: LiveData<List<Category>> = liveAddRemoveCategoryList
+    private val liveAddRemoveCategoryList = MutableLiveData<List<CategoryDto>>()
+    val addRemoveCategoryList: LiveData<List<CategoryDto>> = liveAddRemoveCategoryList
 
     private val liveLastViewedIndex = MutableLiveData<Int>()
     val lastViewedIndex: LiveData<Int> = liveLastViewedIndex
@@ -27,7 +27,7 @@ class EditCategoriesViewModel : BaseViewModel() {
     private val liveCategoryPhraseList = MutableLiveData<List<Phrase>>()
     val categoryPhraseList: LiveData<List<Phrase>> = liveCategoryPhraseList
 
-    private var overallCategories = listOf<Category>()
+    private var overallCategories = listOf<CategoryDto>()
 
     private val localizedResourceUtility: LocalizedResourceUtility by inject()
 
@@ -60,7 +60,7 @@ class EditCategoriesViewModel : BaseViewModel() {
         }
     }
 
-    fun deleteCategory(category: Category) {
+    fun deleteCategory(category: CategoryDto) {
         backgroundScope.launch {
 
             // Delete any phrases whose only associated category is the one being deleted
@@ -100,7 +100,7 @@ class EditCategoriesViewModel : BaseViewModel() {
         }
     }
 
-    fun deletePhraseFromCategory(phrase: Phrase, category: Category) {
+    fun deletePhraseFromCategory(phrase: Phrase, category: CategoryDto) {
         backgroundScope.launch {
 
             presetsRepository.deletePhrase(phrase)
@@ -118,16 +118,16 @@ class EditCategoriesViewModel : BaseViewModel() {
         }
     }
 
-    fun getUpdatedCategoryName(category: Category): String {
+    fun getUpdatedCategoryName(category: CategoryDto): String {
         val updatedCategory = overallCategories.firstOrNull { it.categoryId == category.categoryId }
         return localizedResourceUtility.getTextFromCategory(updatedCategory)
     }
 
-    fun getUpdatedCategory(category: Category): Category {
+    fun getUpdatedCategory(category: CategoryDto): CategoryDto {
         return overallCategories.first { it.categoryId == category.categoryId }
     }
 
-    fun fetchCategoryPhrases(category: Category) {
+    fun fetchCategoryPhrases(category: CategoryDto) {
         backgroundScope.launch {
             val phrasesForCategory = presetsRepository.getPhrasesForCategory(category.categoryId)
                 .sortedBy { it.sortOrder }
@@ -135,7 +135,7 @@ class EditCategoriesViewModel : BaseViewModel() {
         }
     }
 
-    fun moveCategoryUp(category: Category) {
+    fun moveCategoryUp(category: CategoryDto) {
         backgroundScope.launch {
             val catIndex = overallCategories.indexOf(category)
             if (catIndex > 0) {
@@ -151,7 +151,7 @@ class EditCategoriesViewModel : BaseViewModel() {
         }
     }
 
-    fun moveCategoryDown(category: Category) {
+    fun moveCategoryDown(category: CategoryDto) {
         backgroundScope.launch {
             val catIndex = overallCategories.indexOf(category)
             if (catIndex > -1) {

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoryMenuViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoryMenuViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import com.willowtree.vocable.BaseViewModel
 import com.willowtree.vocable.presets.PresetCategories
 import com.willowtree.vocable.presets.PresetsRepository
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import kotlinx.coroutines.launch
 import org.koin.core.component.inject
 
@@ -13,8 +13,8 @@ class EditCategoryMenuViewModel : BaseViewModel() {
 
     private val presetsRepository: PresetsRepository by inject()
 
-    private val _currentCategory = MutableLiveData<Category>()
-    val currentCategory: LiveData<Category> = _currentCategory
+    private val _currentCategory = MutableLiveData<CategoryDto>()
+    val currentCategory: LiveData<CategoryDto> = _currentCategory
 
     private val _lastCategoryRemaining = MutableLiveData<Boolean>()
     val lastCategoryRemaining: LiveData<Boolean> = _lastCategoryRemaining

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoryPhrasesFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoryPhrasesFragment.kt
@@ -17,7 +17,7 @@ import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
 import com.willowtree.vocable.databinding.FragmentEditCategoryPhrasesBinding
 import com.willowtree.vocable.presets.PresetCategories
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import com.willowtree.vocable.settings.customcategories.CustomCategoryPhraseListFragment
 import com.willowtree.vocable.utils.VocableFragmentStateAdapter
@@ -32,7 +32,7 @@ class EditCategoryPhrasesFragment : BaseFragment<FragmentEditCategoryPhrasesBind
 
     private var maxPhrases = 1
     private lateinit var phrasesAdapter: PhrasesPagerAdapter
-    private lateinit var category: Category
+    private lateinit var category: CategoryDto
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/willowtree/vocable/settings/customcategories/CustomCategoryPhraseListFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/customcategories/CustomCategoryPhraseListFragment.kt
@@ -12,7 +12,7 @@ import com.willowtree.vocable.BaseViewModelFactory
 import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
 import com.willowtree.vocable.databinding.FragmentCustomCategoryPhraseListBinding
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import com.willowtree.vocable.settings.EditCategoriesViewModel
 import com.willowtree.vocable.settings.EditCategoryPhrasesFragmentDirections
@@ -27,7 +27,7 @@ class CustomCategoryPhraseListFragment : BaseFragment<FragmentCustomCategoryPhra
 
         fun newInstance(
             phrases: List<Phrase>,
-            category: Category
+            category: CategoryDto
         ): CustomCategoryPhraseListFragment {
             return CustomCategoryPhraseListFragment().apply {
                 arguments = bundleOf(KEY_PHRASES to ArrayList(phrases), KEY_CATEGORY to category)
@@ -36,7 +36,7 @@ class CustomCategoryPhraseListFragment : BaseFragment<FragmentCustomCategoryPhra
     }
 
     private lateinit var editCategoriesViewModel: EditCategoriesViewModel
-    private lateinit var category: Category
+    private lateinit var category: CategoryDto
 
     private val onPhraseEdit = { phrase: Phrase ->
         val action = EditCategoryPhrasesFragmentDirections.actionEditCategoryPhrasesFragmentToEditPhrasesKeyboardFragment(phrase)
@@ -55,7 +55,7 @@ class CustomCategoryPhraseListFragment : BaseFragment<FragmentCustomCategoryPhra
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        arguments?.getParcelable<Category>(KEY_CATEGORY)?.let {
+        arguments?.getParcelable<CategoryDto>(KEY_CATEGORY)?.let {
             category = it
         }
 

--- a/app/src/main/java/com/willowtree/vocable/settings/customcategories/adapter/CustomCategoryPhraseAdapter.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/customcategories/adapter/CustomCategoryPhraseAdapter.kt
@@ -8,8 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.willowtree.vocable.R
 import com.willowtree.vocable.customviews.NoSayTextButton
 import com.willowtree.vocable.databinding.EditCustomCategoryPhraseItemBinding
-import com.willowtree.vocable.presets.PresetCategories
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import org.koin.core.component.KoinComponent
@@ -20,7 +19,7 @@ class CustomCategoryPhraseAdapter(
     private val numRows: Int,
     private val onPhraseEdit: (Phrase) -> Unit,
     private val onPhraseDelete: (Phrase) -> Unit,
-    private val category: Category
+    private val category: CategoryDto
 ) : RecyclerView.Adapter<CustomCategoryPhraseAdapter.CustomCategoryPhraseViewHolder>(),
     KoinComponent {
 

--- a/app/src/main/java/com/willowtree/vocable/utils/LocalizedResourceUtility.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/LocalizedResourceUtility.kt
@@ -2,7 +2,7 @@ package com.willowtree.vocable.utils
 
 import android.content.Context
 import android.content.res.Resources
-import com.willowtree.vocable.room.Category
+import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -11,7 +11,7 @@ class LocalizedResourceUtility : KoinComponent {
 
     val resources: Resources = get<Context>().resources
 
-    fun getTextFromCategory(category: Category?): String {
+    fun getTextFromCategory(category: CategoryDto?): String {
 
         return category?.localizedName?.let {
             LocaleUtils.getTextForLocale(it)

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -29,7 +29,7 @@
         <argument
             android:name="category"
             android:defaultValue="@null"
-            app:argType="com.willowtree.vocable.room.Category"
+            app:argType="com.willowtree.vocable.room.CategoryDto"
             app:nullable="true" />
         <action
             android:id="@+id/action_editCategoriesKeyboardFragment_to_editCategoryMenuFragment"
@@ -41,7 +41,7 @@
         android:label="EditCategoryPhrasesFragment">
         <argument
             android:name="category"
-            app:argType="com.willowtree.vocable.room.Category" />
+            app:argType="com.willowtree.vocable.room.CategoryDto" />
         <action
             android:id="@+id/action_editCategoryPhrasesFragment_to_editCategoriesKeyboardFragment"
             app:destination="@id/editCategoriesKeyboardFragment" />
@@ -79,7 +79,7 @@
         android:label="AddPhraseKeyboardFragment">
         <argument
             android:name="category"
-            app:argType="com.willowtree.vocable.room.Category" />
+            app:argType="com.willowtree.vocable.room.CategoryDto" />
     </fragment>
     <fragment
         android:id="@+id/settingsFragment"
@@ -143,7 +143,7 @@
         tools:layout="@layout/fragment_edit_category_menu" >
         <argument
             android:name="category"
-            app:argType="com.willowtree.vocable.room.Category" />
+            app:argType="com.willowtree.vocable.room.CategoryDto" />
         <action
             android:id="@+id/action_editCategoryMenuFragment_to_editCategoryPhrasesFragment"
             app:destination="@id/editCategoryPhrasesFragment" />

--- a/app/src/test/java/com/willowtree/vocable/LiveDataExt.kt
+++ b/app/src/test/java/com/willowtree/vocable/LiveDataExt.kt
@@ -1,0 +1,32 @@
+package com.willowtree.vocable
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+fun <T> LiveData<T>.getOrAwaitValue(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(o: T?) {
+            data = o
+            latch.countDown()
+            this@getOrAwaitValue.removeObserver(this)
+        }
+    }
+
+    this.observeForever(observer)
+
+    // Don't wait indefinitely if the LiveData is not set.
+    if (!latch.await(time, timeUnit)) {
+        throw TimeoutException("LiveData value was never set.")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/app/src/test/java/com/willowtree/vocable/MainDispatcherRule.kt
+++ b/app/src/test/java/com/willowtree/vocable/MainDispatcherRule.kt
@@ -1,0 +1,21 @@
+package com.willowtree.vocable
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/willowtree/vocable/presets/FakePresetsRepository.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/FakePresetsRepository.kt
@@ -1,0 +1,47 @@
+package com.willowtree.vocable.presets
+
+import com.willowtree.vocable.room.CategoryDto
+import com.willowtree.vocable.room.Phrase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakePresetsRepository : IPresetsRepository {
+
+    val _allCategories = MutableStateFlow(
+        listOf(
+            CategoryDto(
+                categoryId = "1",
+                creationDate = 0L,
+                resourceId = null,
+                localizedName = mapOf("en_US" to "category"),
+                hidden = false,
+                sortOrder = 0
+            )
+        )
+    )
+
+    var _categoriesToPhrases = mapOf(
+        "1" to listOf(
+            Phrase(
+                phraseId = 1L,
+                parentCategoryId = "1",
+                creationDate = 0L,
+                lastSpokenDate = 0L,
+                localizedUtterance = mapOf("en_US" to "Hello"),
+                sortOrder = 0
+            )
+        )
+    )
+
+    override suspend fun getPhrasesForCategory(categoryId: String): List<Phrase> {
+        return _categoriesToPhrases[categoryId]!! // go ahead and blow up if our test data isn't valid
+    }
+
+    override suspend fun addPhraseToRecents(phrase: Phrase) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllCategoriesFlow(): Flow<List<CategoryDto>> {
+        return _allCategories
+    }
+}

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -1,0 +1,22 @@
+package com.willowtree.vocable.presets
+
+import org.junit.Test
+
+class PresetsViewModelTest {
+
+    @Test
+    fun `category list passed through`() {
+
+    }
+
+    @Test
+    fun `selected category ID set to first`() {
+
+    }
+
+    @Test
+    fun `current phrases updated when category ID changed`() {
+
+    }
+
+}

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -1,22 +1,176 @@
 package com.willowtree.vocable.presets
 
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.willowtree.vocable.CategoriesUseCase
+import com.willowtree.vocable.MainDispatcherRule
+import com.willowtree.vocable.getOrAwaitValue
+import com.willowtree.vocable.room.CategoryDto
+import com.willowtree.vocable.room.Phrase
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
 import org.junit.Test
 
 class PresetsViewModelTest {
 
-    @Test
-    fun `category list passed through`() {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val fakePresetsRepository = FakePresetsRepository()
+
+    private fun createViewModel(): PresetsViewModel {
+        return PresetsViewModel(
+            fakePresetsRepository,
+            CategoriesUseCase(fakePresetsRepository)
+        )
     }
 
     @Test
-    fun `selected category ID set to first`() {
+    fun `category list passed through`() {
+        fakePresetsRepository._allCategories.update {
+            listOf(
+                CategoryDto(
+                    categoryId = "1",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = mapOf("en_US" to "category"),
+                    hidden = false,
+                    sortOrder = 0
+                )
+            )
+        }
 
+        val vm = createViewModel()
+
+        assertEquals(
+            listOf(
+                CategoryDto(
+                    categoryId = "1",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = mapOf("en_US" to "category"),
+                    hidden = false,
+                    sortOrder = 0
+                )
+            ),
+            vm.categoryList.getOrAwaitValue()
+        )
+    }
+
+    @Test
+    fun `selected category set`() = runTest(UnconfinedTestDispatcher()) {
+        fakePresetsRepository._allCategories.update {
+            listOf(
+                CategoryDto(
+                    categoryId = "1",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = mapOf("en_US" to "category"),
+                    hidden = false,
+                    sortOrder = 0
+                ),
+                CategoryDto(
+                    categoryId = "2",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = mapOf("en_US" to "second category"),
+                    hidden = false,
+                    sortOrder = 0
+                )
+            )
+        }
+        val vm = createViewModel()
+        vm.onCategorySelected("1")
+
+        //TODO: PK - Turbine may make this less painful, punting for now
+        var category: CategoryDto? = null
+        val job = launch {
+            vm.selectedCategory.collect {
+                category = it
+            }
+        }
+        job.cancel()
+
+        assertEquals(
+            CategoryDto(
+                categoryId = "1",
+                creationDate = 0L,
+                resourceId = null,
+                localizedName = mapOf("en_US" to "category"),
+                hidden = false,
+                sortOrder = 0
+            ),
+            category
+        )
     }
 
     @Test
     fun `current phrases updated when category ID changed`() {
+        fakePresetsRepository._allCategories.update {
+            listOf(
+                CategoryDto(
+                    categoryId = "1",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = mapOf("en_US" to "category"),
+                    hidden = false,
+                    sortOrder = 0
+                ),
+                CategoryDto(
+                    categoryId = "2",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = mapOf("en_US" to "second category"),
+                    hidden = false,
+                    sortOrder = 0
+                )
+            )
+        }
+        fakePresetsRepository._categoriesToPhrases = mapOf(
+            "1" to listOf(
+                Phrase(
+                    phraseId = 1L,
+                    parentCategoryId = "1",
+                    creationDate = 0L,
+                    lastSpokenDate = 0L,
+                    localizedUtterance = mapOf("en_US" to "Hello"),
+                    sortOrder = 0
+                )
+            ),
+            "2" to listOf(
+                Phrase(
+                    phraseId = 2L,
+                    parentCategoryId = "2",
+                    creationDate = 0L,
+                    lastSpokenDate = 0L,
+                    localizedUtterance = mapOf("en_US" to "Goodbye"),
+                    sortOrder = 0
+                )
+            )
+        )
+        val vm = createViewModel()
+        vm.onCategorySelected("2")
 
+        assertEquals(
+            listOf(
+                Phrase(
+                    phraseId = 2L,
+                    parentCategoryId = "2",
+                    creationDate = 0L,
+                    lastSpokenDate = 0L,
+                    localizedUtterance = mapOf("en_US" to "Goodbye"),
+                    sortOrder = 0
+                ),
+                null
+            ),
+            vm.currentPhrases.getOrAwaitValue()
+        )
     }
 
 }


### PR DESCRIPTION
Description: 
First steps in separating our Category domain model from the database model. Renamed the DB model and stopped duplicating Category state in PresetsViewModel.

Recommend stepping through by-commit. PR is a little larger than I wanted, but I wanted to get the tests in for PresetsViewModel to add confidence in the review and hopefully make it a little easier.

Part of #408 
