### PR TITLE
Starting to use Category instead of Category DTO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,13 @@ jobs:
       - name: Run Unit Tests
         run: ./gradlew testDebug
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: app/build/reports/
+
       - name: Assemble Debug Variant
         env:
           VERSION_CODE: ${{ github.run_number }}

--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -10,6 +10,8 @@ import com.willowtree.vocable.settings.EditCategoriesViewModel
 import com.willowtree.vocable.utils.DateProvider
 import com.willowtree.vocable.utils.ILocalizedResourceUtility
 import com.willowtree.vocable.utils.JavaDateProvider
+import com.willowtree.vocable.utils.JavaLocaleProvider
+import com.willowtree.vocable.utils.LocaleProvider
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import com.willowtree.vocable.utils.RandomUUIDProvider
 import com.willowtree.vocable.utils.UUIDProvider
@@ -28,8 +30,9 @@ object AppKoinModule {
         single { CategoriesUseCase(get()) }
         single { RandomUUIDProvider() } bind UUIDProvider::class
         single { JavaDateProvider() } bind DateProvider::class
+        single { JavaLocaleProvider() } bind LocaleProvider::class
         viewModel { PresetsViewModel(get(), get()) }
         viewModel { EditCategoriesViewModel(get(), get()) }
-        viewModel { AddUpdateCategoryViewModel(get(), get(), get(), get()) }
+        viewModel { AddUpdateCategoryViewModel(get(), get(), get(), get(), get()) }
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -5,9 +5,14 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.willowtree.vocable.presets.IPresetsRepository
 import com.willowtree.vocable.presets.PresetsRepository
 import com.willowtree.vocable.presets.PresetsViewModel
+import com.willowtree.vocable.settings.AddUpdateCategoryViewModel
 import com.willowtree.vocable.settings.EditCategoriesViewModel
+import com.willowtree.vocable.utils.DateProvider
 import com.willowtree.vocable.utils.ILocalizedResourceUtility
+import com.willowtree.vocable.utils.JavaDateProvider
 import com.willowtree.vocable.utils.LocalizedResourceUtility
+import com.willowtree.vocable.utils.RandomUUIDProvider
+import com.willowtree.vocable.utils.UUIDProvider
 import com.willowtree.vocable.utils.VocableSharedPreferences
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.bind
@@ -21,7 +26,10 @@ object AppKoinModule {
         single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
         single { LocalizedResourceUtility() } bind ILocalizedResourceUtility::class
         single { CategoriesUseCase(get()) }
+        single { RandomUUIDProvider() } bind UUIDProvider::class
+        single { JavaDateProvider() } bind DateProvider::class
         viewModel { PresetsViewModel(get(), get()) }
         viewModel { EditCategoriesViewModel(get(), get()) }
+        viewModel { AddUpdateCategoryViewModel(get(), get(), get(), get()) }
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/CategoriesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/CategoriesUseCase.kt
@@ -1,15 +1,32 @@
 package com.willowtree.vocable
 
+import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.presets.IPresetsRepository
-import com.willowtree.vocable.room.CategoryDto
+import com.willowtree.vocable.presets.asCategory
+import com.willowtree.vocable.presets.asDto
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class CategoriesUseCase(
     private val presetsRepository: IPresetsRepository
 ) {
 
-    fun categories(): Flow<List<CategoryDto>> {
+    fun categories(): Flow<List<Category>> {
         return presetsRepository.getAllCategoriesFlow()
+            .map { categoryDtoList -> categoryDtoList.map { it.asCategory() } }
+
+    }
+
+    suspend fun updateCategory(category: Category) {
+        presetsRepository.updateCategory(category.asDto())
+    }
+
+    suspend fun updateCategories(categories: List<Category>) {
+        presetsRepository.updateCategories(categories.map { it.asDto() })
+    }
+
+    suspend fun addCategory(category: Category) {
+        presetsRepository.addCategory(category.asDto())
     }
 
 }

--- a/app/src/main/java/com/willowtree/vocable/presets/CategoriesFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/CategoriesFragment.kt
@@ -16,7 +16,6 @@ import com.willowtree.vocable.customviews.CategoryButton
 import com.willowtree.vocable.customviews.PointerListener
 import com.willowtree.vocable.databinding.CategoriesFragmentBinding
 import com.willowtree.vocable.databinding.CategoryButtonBinding
-import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.utils.LocalizedResourceUtility
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ViewModelOwner
@@ -27,7 +26,7 @@ class CategoriesFragment : BaseFragment<CategoriesFragmentBinding>() {
     companion object {
         const val KEY_CATEGORIES = "KEY_CATEGORIES"
 
-        fun newInstance(categories: List<CategoryDto>): CategoriesFragment {
+        fun newInstance(categories: List<Category>): CategoriesFragment {
             return CategoriesFragment().apply {
                 arguments = Bundle().apply {
                     putParcelableArrayList(KEY_CATEGORIES, ArrayList(categories))
@@ -49,12 +48,12 @@ class CategoriesFragment : BaseFragment<CategoriesFragmentBinding>() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         super.onCreateView(inflater, container, savedInstanceState)
         maxCategories = resources.getInteger(R.integer.max_categories)
         val isTablet = resources.getBoolean(R.bool.is_tablet)
 
-        val categories = arguments?.getParcelableArrayList<CategoryDto>(KEY_CATEGORIES)
+        val categories = arguments?.getParcelableArrayList<Category>(KEY_CATEGORIES)
         categories?.forEachIndexed { index, category ->
             val categoryButton =
                 CategoryButtonBinding.inflate(inflater, binding.categoryButtonContainer, false)
@@ -114,7 +113,7 @@ class CategoriesFragment : BaseFragment<CategoriesFragmentBinding>() {
             category?.let {
                 binding.categoryButtonContainer.children.forEach {
                     if (it is CategoryButton) {
-                        it.isSelected = (it.tag as? CategoryDto)?.categoryId == category.categoryId
+                        it.isSelected = (it.tag as Category).categoryId == category.categoryId
                     }
                 }
             }

--- a/app/src/main/java/com/willowtree/vocable/presets/Category.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/Category.kt
@@ -1,0 +1,33 @@
+package com.willowtree.vocable.presets
+
+import android.os.Parcelable
+import com.willowtree.vocable.room.CategoryDto
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Category(
+    val categoryId: String,
+    val creationDate: Long,
+    val resourceId: Int?,
+    val localizedName: Map<String, String>?,
+    var hidden: Boolean,
+    var sortOrder: Int
+) : Parcelable
+
+fun CategoryDto.asCategory(): Category = Category(
+    categoryId,
+    creationDate,
+    resourceId,
+    localizedName,
+    hidden,
+    sortOrder
+)
+
+fun Category.asDto(): CategoryDto = CategoryDto(
+    categoryId,
+    creationDate,
+    resourceId,
+    localizedName,
+    hidden,
+    sortOrder
+)

--- a/app/src/main/java/com/willowtree/vocable/presets/IPresetsRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/IPresetsRepository.kt
@@ -8,8 +8,18 @@ import kotlinx.coroutines.flow.Flow
 interface IPresetsRepository {
     suspend fun getPhrasesForCategory(categoryId: String): List<Phrase>
     suspend fun addPhraseToRecents(phrase: Phrase)
+
+    /**
+     * Return all categories, sorted by [CategoryDto.sortOrder]
+     */
     fun getAllCategoriesFlow(): Flow<List<CategoryDto>>
+
+    /**
+     * Return all categories, sorted by [CategoryDto.sortOrder]
+     */
     suspend fun getAllCategories(): List<CategoryDto>
     suspend fun deletePhrase(phrase: Phrase)
     suspend fun updateCategories(categories: List<CategoryDto>)
+    suspend fun updateCategory(category: CategoryDto)
+    suspend fun addCategory(category: CategoryDto)
 }

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
@@ -16,7 +16,6 @@ import androidx.viewpager2.widget.ViewPager2
 import com.willowtree.vocable.*
 import com.willowtree.vocable.customviews.PointerListener
 import com.willowtree.vocable.databinding.FragmentPresetsBinding
-import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import com.willowtree.vocable.utils.SpokenText
 import com.willowtree.vocable.utils.VocableFragmentStateAdapter
@@ -137,7 +136,7 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
             val action =
                 presetsViewModel.selectedCategory.value?.let { category ->
                     PresetsFragmentDirections.actionPresetsFragmentToAddPhraseKeyboardFragment(
-                        category
+                        category.asDto()
                     )
                 }
             if (action != null) {
@@ -216,7 +215,7 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
                 val action =
                     presetsViewModel.selectedCategory.value?.let { category ->
                         PresetsFragmentDirections.actionPresetsFragmentToAddPhraseKeyboardFragment(
-                            category
+                            category.asDto()
                         )
                     }
                 if (action != null) {
@@ -243,7 +242,7 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
         }
     }
 
-    private fun handleCategories(categories: List<CategoryDto>) {
+    private fun handleCategories(categories: List<Category>) {
         with(binding.categoryView) {
             val categoriesExist = categories.isNotEmpty()
             // if there are no categories to show (the user has hidden them all), then show the empty state
@@ -329,7 +328,7 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
     }
 
     inner class CategoriesPagerAdapter(fm: FragmentManager) :
-        VocableFragmentStateAdapter<CategoryDto>(fm, viewLifecycleOwner.lifecycle) {
+        VocableFragmentStateAdapter<Category>(fm, viewLifecycleOwner.lifecycle) {
 
         override fun getMaxItemsPerPage(): Int = maxCategories
 
@@ -338,7 +337,7 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
 
         fun getSize(): Int = items.size
 
-        fun getCategory(position: Int): CategoryDto {
+        fun getCategory(position: Int): Category {
             return if (position >= items.size) {
                 items[position % items.size]
             } else {

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsRepository.kt
@@ -72,7 +72,7 @@ class PresetsRepository(val context: Context) : KoinComponent, IPresetsRepositor
         }
     }
 
-    suspend fun addCategory(category: CategoryDto) {
+    override suspend fun addCategory(category: CategoryDto) {
         database.categoryDao().insertCategory(category)
     }
 
@@ -100,7 +100,7 @@ class PresetsRepository(val context: Context) : KoinComponent, IPresetsRepositor
         database.phraseDao().updatePhrase(phrase)
     }
 
-    suspend fun updateCategory(category: CategoryDto) {
+    override suspend fun updateCategory(category: CategoryDto) {
         database.categoryDao().updateCategory(category)
     }
 

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.CategoriesUseCase
-import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -23,17 +22,17 @@ class PresetsViewModel(
     categoriesUseCase: CategoriesUseCase
 ) : ViewModel() {
 
-    val categoryList: LiveData<List<CategoryDto>> = categoriesUseCase.categories().asLiveData()
+    val categoryList: LiveData<List<Category>> = categoriesUseCase.categories().asLiveData()
 
     // Will only ever be null immediately on init
     private val liveSelectedCategoryId = MutableStateFlow<String?>(null)
-    val selectedCategory: StateFlow<CategoryDto?> = combine(
+    val selectedCategory: StateFlow<Category?> = combine(
         categoriesUseCase.categories(),
         liveSelectedCategoryId
     ) { categories, selectedId ->
         categories.find { it.categoryId == selectedId }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), null)
-    val selectedCategoryLiveData: LiveData<CategoryDto?> = selectedCategory.asLiveData()
+    val selectedCategoryLiveData: LiveData<Category?> = selectedCategory.asLiveData()
 
     val currentPhrases: LiveData<List<Phrase?>> = liveSelectedCategoryId.map { categoryId ->
         if (categoryId == null) return@map emptyList<Phrase>()

--- a/app/src/main/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModel.kt
@@ -8,17 +8,18 @@ import com.willowtree.vocable.CategoriesUseCase
 import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.utils.DateProvider
 import com.willowtree.vocable.utils.ILocalizedResourceUtility
+import com.willowtree.vocable.utils.LocaleProvider
 import com.willowtree.vocable.utils.UUIDProvider
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import java.util.Locale
 
 class AddUpdateCategoryViewModel(
     private val categoriesUseCase: CategoriesUseCase,
     private val localizedResourceUtility: ILocalizedResourceUtility,
     private val uuidProvider: UUIDProvider,
-    private val dateProvider: DateProvider
+    private val dateProvider: DateProvider,
+    private val localeProvider: LocaleProvider
 ) : ViewModel() {
 
     companion object {
@@ -41,13 +42,13 @@ class AddUpdateCategoryViewModel(
 
             val toUpdate = categoriesUseCase.categories().first().firstOrNull { it.categoryId == categoryId }
             toUpdate?.let {
-                val currentName = it.localizedName?.get(Locale.getDefault().toString())
+                val currentName = it.localizedName?.get(localeProvider.getDefaultLocaleString())
 
                 if (currentName == updatedName) {
                     return@let
                 }
 
-                val updatedNameMap = mapOf(Locale.getDefault().toString() to updatedName)
+                val updatedNameMap = mapOf(localeProvider.getDefaultLocaleString() to updatedName)
 
                 categoriesUseCase.updateCategory(it.copy(localizedName = updatedNameMap))
                 liveShowCategoryUpdateMessage.postValue(true)
@@ -83,7 +84,7 @@ class AddUpdateCategoryViewModel(
                 uuidProvider.randomUUIDString(),
                 dateProvider.currentTimeMillis(),
                 null,
-                mapOf(Pair(Locale.getDefault().toString(), categoryName)),
+                mapOf(Pair(localeProvider.getDefaultLocaleString(), categoryName)),
                 false,
                 firstHiddenIndex
             )

--- a/app/src/main/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModel.kt
@@ -4,42 +4,32 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.willowtree.vocable.presets.PresetsRepository
-import com.willowtree.vocable.room.CategoryDto
-import com.willowtree.vocable.utils.LocalizedResourceUtility
+import com.willowtree.vocable.CategoriesUseCase
+import com.willowtree.vocable.presets.Category
+import com.willowtree.vocable.utils.DateProvider
+import com.willowtree.vocable.utils.ILocalizedResourceUtility
+import com.willowtree.vocable.utils.UUIDProvider
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
-import java.util.*
+import java.util.Locale
 
-class AddUpdateCategoryViewModel : ViewModel(), KoinComponent {
+class AddUpdateCategoryViewModel(
+    private val categoriesUseCase: CategoriesUseCase,
+    private val localizedResourceUtility: ILocalizedResourceUtility,
+    private val uuidProvider: UUIDProvider,
+    private val dateProvider: DateProvider
+) : ViewModel() {
 
     companion object {
         private const val CATEGORY_MESSAGE_DELAY = 2000L
     }
-
-    private val presetsRepository: PresetsRepository by inject()
-
-    private val localizedResourceUtility: LocalizedResourceUtility by inject()
 
     private val liveShowCategoryUpdateMessage = MutableLiveData<Boolean>()
     val showCategoryUpdateMessage: LiveData<Boolean> = liveShowCategoryUpdateMessage
 
     private val liveShowDuplicateCategoryMessage = MutableLiveData<Boolean>()
     val showDuplicateCategoryMessage: LiveData<Boolean> = liveShowDuplicateCategoryMessage
-
-    private var allCategories = listOf<CategoryDto>()
-
-    init {
-        populateAllCategories()
-    }
-
-    private fun populateAllCategories() {
-        viewModelScope.launch {
-            allCategories = presetsRepository.getAllCategories()
-        }
-    }
 
     fun updateCategory(categoryId: String, updatedName: String) {
         viewModelScope.launch {
@@ -49,7 +39,7 @@ class AddUpdateCategoryViewModel : ViewModel(), KoinComponent {
                 return@launch
             }
 
-            val toUpdate = allCategories.firstOrNull { it.categoryId == categoryId }
+            val toUpdate = categoriesUseCase.categories().first().firstOrNull { it.categoryId == categoryId }
             toUpdate?.let {
                 val currentName = it.localizedName?.get(Locale.getDefault().toString())
 
@@ -59,9 +49,7 @@ class AddUpdateCategoryViewModel : ViewModel(), KoinComponent {
 
                 val updatedNameMap = mapOf(Locale.getDefault().toString() to updatedName)
 
-                it.localizedName = updatedNameMap ?: mapOf()
-
-                presetsRepository.updateCategory(it)
+                categoriesUseCase.updateCategory(it.copy(localizedName = updatedNameMap))
                 liveShowCategoryUpdateMessage.postValue(true)
                 delay(CATEGORY_MESSAGE_DELAY)
                 liveShowCategoryUpdateMessage.postValue(false)
@@ -71,6 +59,7 @@ class AddUpdateCategoryViewModel : ViewModel(), KoinComponent {
 
     fun addCategory(categoryName: String) {
         viewModelScope.launch {
+            val allCategories = categoriesUseCase.categories().first()
             // Don't allow duplicate category names
             if (categoryNameExists(categoryName)) {
                 liveShowDuplicateCategoryMessage.postValue(true)
@@ -90,21 +79,16 @@ class AddUpdateCategoryViewModel : ViewModel(), KoinComponent {
                 it.sortOrder++
             }
 
-            val newCategory = CategoryDto(
-                UUID.randomUUID().toString(),
-                System.currentTimeMillis(),
+            val newCategory = Category(
+                uuidProvider.randomUUIDString(),
+                dateProvider.currentTimeMillis(),
                 null,
                 mapOf(Pair(Locale.getDefault().toString(), categoryName)),
                 false,
                 firstHiddenIndex
             )
 
-            allCategories = allCategories
-                .toMutableList()
-                .apply { add(newCategory) }
-                .sortedBy { it.sortOrder }
-
-            with(presetsRepository) {
+            with(categoriesUseCase) {
                 addCategory(newCategory)
                 updateCategories(listToUpdate)
             }
@@ -116,7 +100,7 @@ class AddUpdateCategoryViewModel : ViewModel(), KoinComponent {
     }
 
     private suspend fun categoryNameExists(categoryName: String): Boolean {
-        val allCategories = presetsRepository.getAllCategories()
+        val allCategories = categoriesUseCase.categories().first()
         allCategories.forEach {
             val name = localizedResourceUtility.getTextFromCategory(it)
             if (name == categoryName) {

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesKeyboardFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesKeyboardFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import android.widget.Toast
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -13,13 +12,14 @@ import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
 import com.willowtree.vocable.databinding.FragmentEditKeyboardBinding
 import com.willowtree.vocable.room.CategoryDto
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class EditCategoriesKeyboardFragment : EditKeyboardFragment() {
 
     override val bindingInflater: BindingInflater<FragmentEditKeyboardBinding> =
         FragmentEditKeyboardBinding::inflate
 
-    private val viewModel: AddUpdateCategoryViewModel by viewModels()
+    private val viewModel: AddUpdateCategoryViewModel by viewModel()
 
     private val args: EditCategoriesKeyboardFragmentArgs by navArgs()
 

--- a/app/src/main/java/com/willowtree/vocable/utils/DateProvider.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/DateProvider.kt
@@ -1,0 +1,5 @@
+package com.willowtree.vocable.utils
+
+interface DateProvider {
+    fun currentTimeMillis(): Long
+}

--- a/app/src/main/java/com/willowtree/vocable/utils/ILocalizedResourceUtility.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/ILocalizedResourceUtility.kt
@@ -1,7 +1,9 @@
 package com.willowtree.vocable.utils
 
+import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.room.CategoryDto
 
 interface ILocalizedResourceUtility {
+    fun getTextFromCategory(category: Category?): String
     fun getTextFromCategory(category: CategoryDto?): String
 }

--- a/app/src/main/java/com/willowtree/vocable/utils/JavaDateProvider.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/JavaDateProvider.kt
@@ -1,0 +1,5 @@
+package com.willowtree.vocable.utils
+
+class JavaDateProvider : DateProvider {
+    override fun currentTimeMillis(): Long = System.currentTimeMillis()
+}

--- a/app/src/main/java/com/willowtree/vocable/utils/JavaLocaleProvider.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/JavaLocaleProvider.kt
@@ -1,0 +1,8 @@
+package com.willowtree.vocable.utils
+
+import java.util.Locale
+
+class JavaLocaleProvider : LocaleProvider {
+    override fun getDefaultLocaleString(): String =
+        Locale.getDefault().toString()
+}

--- a/app/src/main/java/com/willowtree/vocable/utils/LocaleProvider.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/LocaleProvider.kt
@@ -1,0 +1,5 @@
+package com.willowtree.vocable.utils
+
+interface LocaleProvider {
+    fun getDefaultLocaleString(): String
+}

--- a/app/src/main/java/com/willowtree/vocable/utils/LocalizedResourceUtility.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/LocalizedResourceUtility.kt
@@ -2,6 +2,7 @@ package com.willowtree.vocable.utils
 
 import android.content.Context
 import android.content.res.Resources
+import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import org.koin.core.component.KoinComponent
@@ -10,6 +11,19 @@ import org.koin.core.component.get
 class LocalizedResourceUtility : KoinComponent, ILocalizedResourceUtility {
 
     val resources: Resources = get<Context>().resources
+
+    override fun getTextFromCategory(category: Category?): String {
+
+        return category?.localizedName?.let {
+            LocaleUtils.getTextForLocale(it)
+        } ?: category?.resourceId?.let {
+            if (it != 0) {
+                resources.getString(it)
+            } else {
+                ""
+            }
+        } ?: ""
+    }
 
     override fun getTextFromCategory(category: CategoryDto?): String {
 

--- a/app/src/main/java/com/willowtree/vocable/utils/RandomUUIDProvider.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/RandomUUIDProvider.kt
@@ -1,0 +1,9 @@
+package com.willowtree.vocable.utils
+
+import java.util.UUID
+
+class RandomUUIDProvider : UUIDProvider {
+    override fun randomUUIDString(): String {
+        return UUID.randomUUID().toString()
+    }
+}

--- a/app/src/main/java/com/willowtree/vocable/utils/UUIDProvider.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/UUIDProvider.kt
@@ -1,0 +1,5 @@
+package com.willowtree.vocable.utils
+
+interface UUIDProvider {
+    fun randomUUIDString(): String
+}

--- a/app/src/test/java/com/willowtree/vocable/presets/FakePresetsRepository.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/FakePresetsRepository.kt
@@ -4,6 +4,8 @@ import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.Phrase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 
 class FakePresetsRepository : IPresetsRepository {
 
@@ -42,18 +44,30 @@ class FakePresetsRepository : IPresetsRepository {
     }
 
     override fun getAllCategoriesFlow(): Flow<List<CategoryDto>> {
-        return _allCategories
+        return _allCategories.map { categoryDtos -> categoryDtos.sortedBy { it.sortOrder } }
     }
 
     override suspend fun getAllCategories(): List<CategoryDto> {
-        return _allCategories.value
+        return _allCategories.value.sortedBy { it.sortOrder }
     }
 
     override suspend fun deletePhrase(phrase: Phrase) {
         TODO("Not yet implemented")
     }
 
-    override suspend fun updateCategories(categories: List<CategoryDto>) {
-        TODO("Not yet implemented")
+    override suspend fun updateCategories(updatedCategories: List<CategoryDto>) {
+        val allCategories = _allCategories.value.map { originalDto ->
+            updatedCategories.find { it.categoryId == originalDto.categoryId }
+                ?: originalDto
+        }
+        _allCategories.update { allCategories }
+    }
+
+    override suspend fun updateCategory(updatedCategory: CategoryDto) {
+        updateCategories(listOf(updatedCategory))
+    }
+
+    override suspend fun addCategory(category: CategoryDto) {
+        _allCategories.update { it + category }
     }
 }

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -50,7 +50,7 @@ class PresetsViewModelTest {
 
         assertEquals(
             listOf(
-                CategoryDto(
+                Category(
                     categoryId = "1",
                     creationDate = 0L,
                     resourceId = null,
@@ -89,7 +89,7 @@ class PresetsViewModelTest {
         vm.onCategorySelected("1")
 
         //TODO: PK - Turbine may make this less painful, punting for now
-        var category: CategoryDto? = null
+        var category: Category? = null
         val job = launch {
             vm.selectedCategory.collect {
                 category = it
@@ -98,7 +98,7 @@ class PresetsViewModelTest {
         job.cancel()
 
         assertEquals(
-            CategoryDto(
+            Category(
                 categoryId = "1",
                 creationDate = 0L,
                 resourceId = null,

--- a/app/src/test/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
@@ -1,0 +1,123 @@
+package com.willowtree.vocable.settings
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.willowtree.vocable.CategoriesUseCase
+import com.willowtree.vocable.MainDispatcherRule
+import com.willowtree.vocable.presets.Category
+import com.willowtree.vocable.presets.FakePresetsRepository
+import com.willowtree.vocable.room.createCategoryDto
+import com.willowtree.vocable.utils.ConstantUUIDProvider
+import com.willowtree.vocable.utils.FakeDateProvider
+import com.willowtree.vocable.utils.FakeLocalizedResourceUtility
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+class AddUpdateCategoryViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val presetsRepository = FakePresetsRepository()
+    private val categoriesUseCase = CategoriesUseCase(presetsRepository)
+    private val uuidProvider = ConstantUUIDProvider()
+    private val dateProvider = FakeDateProvider()
+
+    private fun createViewModel(): AddUpdateCategoryViewModel {
+        return AddUpdateCategoryViewModel(
+            categoriesUseCase,
+            FakeLocalizedResourceUtility(),
+            uuidProvider,
+            dateProvider
+        )
+    }
+
+    @Test
+    fun `category added`() = runTest {
+        presetsRepository._allCategories.update {
+            listOf(
+                createCategoryDto(
+                    categoryId = "1",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = null,
+                    hidden = false,
+                    sortOrder = 0
+                )
+            )
+        }
+        uuidProvider._uuid = "2"
+        dateProvider._currentTimeMillis = 0L
+
+        val vm = createViewModel()
+
+        vm.addCategory(
+            "New Category"
+        )
+
+        Assert.assertEquals(
+            listOf(
+                Category(
+                    categoryId = "1",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = null,
+                    hidden = false,
+                    sortOrder = 0
+                ),
+                Category(
+                    categoryId = "2",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = mapOf("en_US" to "New Category"),
+                    hidden = false,
+                    sortOrder = 1
+                )
+            ),
+            categoriesUseCase.categories().first()
+        )
+    }
+
+    @Test
+    fun `category updated`() = runTest {
+        presetsRepository._allCategories.update {
+            listOf(
+                createCategoryDto(
+                    categoryId = "1",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = mapOf("en_US" to "Category"),
+                    hidden = false,
+                    sortOrder = 0
+                )
+            )
+        }
+        uuidProvider._uuid = "2"
+        dateProvider._currentTimeMillis = 0L
+
+        val vm = createViewModel()
+
+        vm.updateCategory("1", "New Category")
+
+        Assert.assertEquals(
+            listOf(
+                Category(
+                    categoryId = "1",
+                    creationDate = 0L,
+                    resourceId = null,
+                    localizedName = mapOf("en_US" to "New Category"),
+                    hidden = false,
+                    sortOrder = 0
+                )
+            ),
+            categoriesUseCase.categories().first()
+        )
+    }
+
+}

--- a/app/src/test/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
@@ -8,6 +8,7 @@ import com.willowtree.vocable.presets.FakePresetsRepository
 import com.willowtree.vocable.room.createCategoryDto
 import com.willowtree.vocable.utils.ConstantUUIDProvider
 import com.willowtree.vocable.utils.FakeDateProvider
+import com.willowtree.vocable.utils.FakeLocaleProvider
 import com.willowtree.vocable.utils.FakeLocalizedResourceUtility
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -34,7 +35,8 @@ class AddUpdateCategoryViewModelTest {
             categoriesUseCase,
             FakeLocalizedResourceUtility(),
             uuidProvider,
-            dateProvider
+            dateProvider,
+            FakeLocaleProvider()
         )
     }
 

--- a/app/src/test/java/com/willowtree/vocable/utils/ConstantUUIDProvider.kt
+++ b/app/src/test/java/com/willowtree/vocable/utils/ConstantUUIDProvider.kt
@@ -1,0 +1,8 @@
+package com.willowtree.vocable.utils
+
+class ConstantUUIDProvider : UUIDProvider {
+
+    var _uuid = "1"
+
+    override fun randomUUIDString(): String = _uuid
+}

--- a/app/src/test/java/com/willowtree/vocable/utils/FakeDateProvider.kt
+++ b/app/src/test/java/com/willowtree/vocable/utils/FakeDateProvider.kt
@@ -1,0 +1,8 @@
+package com.willowtree.vocable.utils
+
+class FakeDateProvider : DateProvider {
+
+    var _currentTimeMillis = 0L
+
+    override fun currentTimeMillis(): Long = _currentTimeMillis
+}

--- a/app/src/test/java/com/willowtree/vocable/utils/FakeLocaleProvider.kt
+++ b/app/src/test/java/com/willowtree/vocable/utils/FakeLocaleProvider.kt
@@ -1,0 +1,5 @@
+package com.willowtree.vocable.utils
+
+class FakeLocaleProvider : LocaleProvider {
+    override fun getDefaultLocaleString(): String = "en_US"
+}

--- a/app/src/test/java/com/willowtree/vocable/utils/FakeLocalizedResourceUtility.kt
+++ b/app/src/test/java/com/willowtree/vocable/utils/FakeLocalizedResourceUtility.kt
@@ -1,8 +1,13 @@
 package com.willowtree.vocable.utils
 
+import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.room.CategoryDto
 
 class FakeLocalizedResourceUtility : ILocalizedResourceUtility {
+    override fun getTextFromCategory(category: Category?): String {
+        return category?.localizedName?.entries?.first()?.value ?: ""
+    }
+
     override fun getTextFromCategory(category: CategoryDto?): String {
         return category?.localizedName?.entries?.first()?.value ?: ""
     }


### PR DESCRIPTION
Also trying to balance not making an enormous change all at once, but CategoryDto is pervasive. Adding tests to the AddUpdateCategoryViewModel as well since that's getting touched.

Likely going to have Category get used just on the main screen for now, and leave the "leaf" screens to still use the DTO, to be refactored later

Finish AddUpdateCategoryViewModel cases

Add necessary ViewModel deps to Koin
