### PR TITLE
VOC-427 defaults head tracking to TRUE

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/utils/VocableSharedPreferences.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/VocableSharedPreferences.kt
@@ -74,7 +74,7 @@ class VocableSharedPreferences : KoinComponent {
     }
 
     fun getHeadTrackingEnabled(): Boolean =
-        encryptedPrefs.getBoolean(KEY_HEAD_TRACKING_ENABLED, false)
+        encryptedPrefs.getBoolean(KEY_HEAD_TRACKING_ENABLED, true)
 
     fun setFirstTime() {
         encryptedPrefs.edit().putBoolean(KEY_FIRST_TIME, false).apply()


### PR DESCRIPTION
Description: 
Defaults Head tracking to true via SharedPreferences.

- [X] Acceptance Criteria satisfied
- [X] Regression Testing

Testing explored. Needs Koin-testing added along with some infrastructure. Not sure how to fake SharedPreferences for any value, otherwise intrumentationRunners needed I believe.