### PR TITLE
Fix Crash When Clicking "+" to Add New Category

### DIFF
--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -26,7 +26,8 @@
         <argument
             android:name="category"
             app:argType="com.willowtree.vocable.presets.Category"
-            app:nullable="true" />
+            app:nullable="true"
+            android:defaultValue="@null" />
         <action
             android:id="@+id/action_editCategoriesKeyboardFragment_to_editCategoryMenuFragment"
             app:destination="@id/editCategoryMenuFragment" />


### PR DESCRIPTION
On a fresh install, attempting to add a new category on the categories page would previously result in a crash, as the Edit Categories page didn't handle opening the screen without a category passed in. 

This is mentioned in https://github.com/willowtreeapps/vocable-android/issues/441. This PR just resolves a minor portion of that ticket, the "add new category" that is mentioned as a footnote. 

STRs:
* Open app (fresh install)
* Tap settings button
* Tap Categories and Phrases
 * Tap `+` button

Expected:
The user is brought to a screen to add a new category.

Actual:
The app crashes.

Screenshots/videos: 
![Webm video of the app crashing when add new category clicked](https://github.com/willowtreeapps/vocable-android/assets/58408581/82431f3e-2f3d-45ae-bef9-2991e6fda2d9)
![Webm video of app opening the add new category page correctly](https://github.com/willowtreeapps/vocable-android/assets/58408581/a334d796-2e45-4b09-b8ab-dc4da0c3bfb3)

- [ ] Acceptance Criteria satisfied
- [ ] Regression Testing
