### PR TITLE
Rename PresetsRepository

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -3,9 +3,9 @@ package com.willowtree.vocable
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.willowtree.vocable.facetracking.FaceTrackingViewModel
-import com.willowtree.vocable.presets.IPresetsRepository
+import com.willowtree.vocable.presets.ILegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.PresetCategoriesRepository
-import com.willowtree.vocable.presets.PresetsRepository
+import com.willowtree.vocable.presets.LegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.PresetsViewModel
 import com.willowtree.vocable.presets.RoomPresetCategoriesRepository
 import com.willowtree.vocable.room.RoomStoredCategoriesRepository
@@ -34,7 +34,7 @@ object AppKoinModule {
 
         single { FaceTrackingPermissions(get()) } bind IFaceTrackingPermissions::class
         single { VocableSharedPreferences() } bind IVocableSharedPreferences::class
-        single { PresetsRepository(get()) } bind IPresetsRepository::class
+        single { LegacyCategoriesAndPhrasesRepository(get()) } bind ILegacyCategoriesAndPhrasesRepository::class
         single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
         single { LocalizedResourceUtility() } bind ILocalizedResourceUtility::class
         single { CategoriesUseCase(get(), get(), get(), get(), get()) } bind ICategoriesUseCase::class

--- a/app/src/main/java/com/willowtree/vocable/CategoriesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/CategoriesUseCase.kt
@@ -1,7 +1,7 @@
 package com.willowtree.vocable
 
 import com.willowtree.vocable.presets.Category
-import com.willowtree.vocable.presets.IPresetsRepository
+import com.willowtree.vocable.presets.ILegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.PresetCategoriesRepository
 import com.willowtree.vocable.presets.asCategory
 import com.willowtree.vocable.room.CategorySortOrder
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class CategoriesUseCase(
-    private val presetsRepository: IPresetsRepository,
+    private val presetsRepository: ILegacyCategoriesAndPhrasesRepository,
     private val uuidProvider: UUIDProvider,
     private val localeProvider: LocaleProvider,
     private val storedCategoriesRepository: StoredCategoriesRepository,

--- a/app/src/main/java/com/willowtree/vocable/PhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/PhrasesUseCase.kt
@@ -1,6 +1,6 @@
 package com.willowtree.vocable
 
-import com.willowtree.vocable.presets.IPresetsRepository
+import com.willowtree.vocable.presets.ILegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.Phrase
 import com.willowtree.vocable.presets.PresetCategories
 import com.willowtree.vocable.presets.asPhrase
@@ -9,7 +9,7 @@ import com.willowtree.vocable.utils.DateProvider
 import com.willowtree.vocable.utils.locale.LocalesWithText
 
 class PhrasesUseCase(
-    private val presetsRepository: IPresetsRepository,
+    private val presetsRepository: ILegacyCategoriesAndPhrasesRepository,
     private val dateProvider: DateProvider
 ) {
     suspend fun getPhrasesForCategory(categoryId: String): List<Phrase> {

--- a/app/src/main/java/com/willowtree/vocable/presets/ILegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/ILegacyCategoriesAndPhrasesRepository.kt
@@ -6,8 +6,9 @@ import com.willowtree.vocable.room.PhraseDto
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import kotlinx.coroutines.flow.Flow
 
-//TODO: PK - Rename this once we make the jump to rename [PresetsRepository] -> "RoomPresetsRepository"
-interface IPresetsRepository {
+@Deprecated("This is the old way of accessing categories and phrases. Prefer using" +
+        " ICategoriesUseCase instead.")
+interface ILegacyCategoriesAndPhrasesRepository {
     suspend fun getPhrasesForCategory(categoryId: String): List<PhraseDto>
 
     /**

--- a/app/src/main/java/com/willowtree/vocable/presets/LegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/LegacyCategoriesAndPhrasesRepository.kt
@@ -14,7 +14,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import java.util.Locale
 
-class PresetsRepository(val context: Context) : KoinComponent, IPresetsRepository {
+class LegacyCategoriesAndPhrasesRepository(val context: Context) : KoinComponent, ILegacyCategoriesAndPhrasesRepository {
 
     private val database = VocableDatabase.getVocableDatabase(context)
 

--- a/app/src/main/java/com/willowtree/vocable/settings/AddPhraseViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/AddPhraseViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.PhrasesUseCase
-import com.willowtree.vocable.presets.PresetsRepository
+import com.willowtree.vocable.presets.LegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -14,7 +14,7 @@ import java.util.Locale
 
 class AddPhraseViewModel : ViewModel(), KoinComponent {
 
-    private val presetsRepository: PresetsRepository by inject()
+    private val presetsRepository: LegacyCategoriesAndPhrasesRepository by inject()
     private val phrasesUseCase: PhrasesUseCase by inject()
 
     private val liveShowPhraseAdded = MutableLiveData<Boolean>()

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoryMenuViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoryMenuViewModel.kt
@@ -7,12 +7,12 @@ import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.CategoriesUseCase
 import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.presets.PresetCategories
-import com.willowtree.vocable.presets.PresetsRepository
+import com.willowtree.vocable.presets.LegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.room.CategorySortOrder
 import kotlinx.coroutines.launch
 
 class EditCategoryMenuViewModel(
-    private val presetsRepository: PresetsRepository,
+    private val presetsRepository: LegacyCategoriesAndPhrasesRepository,
     private val categoriesUseCase: CategoriesUseCase
 ) : ViewModel() {
 

--- a/app/src/main/java/com/willowtree/vocable/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/SettingsViewModel.kt
@@ -1,14 +1,11 @@
 package com.willowtree.vocable.settings
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.willowtree.vocable.presets.PresetsRepository
-import com.willowtree.vocable.utils.VocableSharedPreferences
+import com.willowtree.vocable.presets.LegacyCategoriesAndPhrasesRepository
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class SettingsViewModel : ViewModel(), KoinComponent {
 
-    private val presetsRepository: PresetsRepository by inject()
+    private val presetsRepository: LegacyCategoriesAndPhrasesRepository by inject()
 }

--- a/app/src/main/java/com/willowtree/vocable/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/splash/SplashViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.willowtree.vocable.presets.PresetsRepository
+import com.willowtree.vocable.presets.LegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.utils.VocableSharedPreferences
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -12,7 +12,7 @@ import org.koin.core.component.inject
 
 class SplashViewModel : ViewModel(), KoinComponent {
 
-    private val presetsRepository: PresetsRepository by inject()
+    private val presetsRepository: LegacyCategoriesAndPhrasesRepository by inject()
 
     private val sharedPrefs: VocableSharedPreferences by inject()
 

--- a/app/src/test/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
@@ -2,7 +2,7 @@ package com.willowtree.vocable
 
 import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.presets.FakePresetCategoriesRepository
-import com.willowtree.vocable.presets.FakePresetsRepository
+import com.willowtree.vocable.presets.FakeLegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.CategorySortOrder
 import com.willowtree.vocable.room.FakeStoredCategoriesRepository
@@ -17,7 +17,7 @@ import org.junit.Test
 
 class CategoriesUseCaseTest {
 
-    private val fakePresetsRepository = FakePresetsRepository()
+    private val fakePresetsRepository = FakeLegacyCategoriesAndPhrasesRepository()
     private val fakeStoredCategoriesRepository = FakeStoredCategoriesRepository()
     private val fakePresetCategoriesRepository = FakePresetCategoriesRepository()
 

--- a/app/src/test/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.willowtree.vocable
 
 import com.willowtree.vocable.presets.CustomPhrase
-import com.willowtree.vocable.presets.FakePresetsRepository
+import com.willowtree.vocable.presets.FakeLegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.PresetCategories
 import com.willowtree.vocable.room.PhraseDto
 import com.willowtree.vocable.utils.FakeDateProvider
@@ -11,7 +11,7 @@ import org.junit.Test
 
 class PhrasesUseCaseTest {
 
-    private val presetsRepository = FakePresetsRepository()
+    private val presetsRepository = FakeLegacyCategoriesAndPhrasesRepository()
 
     private fun createUseCase(): PhrasesUseCase {
         return PhrasesUseCase(presetsRepository, FakeDateProvider())

--- a/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 
-class FakePresetsRepository : IPresetsRepository {
+class FakeLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepository {
 
     val _allCategories = MutableStateFlow(
         listOf(

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -25,7 +25,7 @@ class PresetsViewModelTest {
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    private val fakePresetsRepository = FakePresetsRepository()
+    private val fakePresetsRepository = FakeLegacyCategoriesAndPhrasesRepository()
     private val fakeCategoriesUseCase = FakeCategoriesUseCase()
 
     private fun createViewModel(): PresetsViewModel {

--- a/app/src/test/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
@@ -4,7 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.willowtree.vocable.FakeCategoriesUseCase
 import com.willowtree.vocable.MainDispatcherRule
 import com.willowtree.vocable.PhrasesUseCase
-import com.willowtree.vocable.presets.FakePresetsRepository
+import com.willowtree.vocable.presets.FakeLegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.createStoredCategory
 import com.willowtree.vocable.utils.FakeDateProvider
 import com.willowtree.vocable.utils.FakeLocalizedResourceUtility
@@ -21,7 +21,7 @@ class EditCategoriesViewModelTest {
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    private val fakePresetsRepository = FakePresetsRepository()
+    private val fakePresetsRepository = FakeLegacyCategoriesAndPhrasesRepository()
     private val categoriesUseCase = FakeCategoriesUseCase()
 
     private fun createViewModel(): EditCategoriesViewModel {


### PR DESCRIPTION
The name already didn't match the responsibility of the class, and with the migration, the name was even more confusing.

#452 
