### PR TITLE
Give non-release builds a pre-release name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,6 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           VERSION_CODE: ${{ github.run_number }}
-          VERSION_NAME: "1.0"
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
         run: |

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         targetSdkVersion 33
         //30 was the last versionCode used on Play Store before implementing CI with github actions
         versionCode Integer.valueOf(System.getenv("VERSION_CODE") ?: 1) + 30
-        versionName System.getenv("VERSION_NAME") ?: "1.0.0"
+        versionName System.getenv("VERSION_NAME") ?: "pre-release" + "(" + versionCode + ")"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         javaCompileOptions {
             annotationProcessorOptions {


### PR DESCRIPTION
Also add the build number to all version names.
This will help make it clearer when we're seeing issues in Firebase, whether or not we should be concerned.