### PR TITLE
Separate Tables for Preset/Stored Phrases

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -8,8 +8,12 @@ import com.willowtree.vocable.presets.LegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.PresetCategoriesRepository
 import com.willowtree.vocable.presets.PresetsViewModel
 import com.willowtree.vocable.presets.RoomPresetCategoriesRepository
+import com.willowtree.vocable.room.PresetPhrasesRepository
+import com.willowtree.vocable.room.RoomPresetPhrasesRepository
 import com.willowtree.vocable.room.RoomStoredCategoriesRepository
+import com.willowtree.vocable.room.RoomStoredPhrasesRepository
 import com.willowtree.vocable.room.StoredCategoriesRepository
+import com.willowtree.vocable.room.StoredPhrasesRepository
 import com.willowtree.vocable.room.VocableDatabase
 import com.willowtree.vocable.settings.AddUpdateCategoryViewModel
 import com.willowtree.vocable.settings.EditCategoriesViewModel
@@ -69,6 +73,8 @@ object AppKoinModule {
         single { JavaLocaleProvider() } bind LocaleProvider::class
         single { RoomStoredCategoriesRepository(get()) } bind StoredCategoriesRepository::class
         single { RoomPresetCategoriesRepository(get()) } bind PresetCategoriesRepository::class
+        single { RoomStoredPhrasesRepository(get()) } bind StoredPhrasesRepository::class
+        single { RoomPresetPhrasesRepository(get()) } bind PresetPhrasesRepository::class
         single { VocableDatabase.getVocableDatabase(get()) }
         viewModel { PresetsViewModel(get(), get()) }
         viewModel { EditCategoriesViewModel(get(), get(), get()) }

--- a/app/src/main/java/com/willowtree/vocable/IPhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/IPhrasesUseCase.kt
@@ -1,0 +1,17 @@
+package com.willowtree.vocable
+
+import com.willowtree.vocable.presets.Phrase
+import com.willowtree.vocable.utils.locale.LocalesWithText
+
+interface IPhrasesUseCase {
+
+    suspend fun getPhrasesForCategory(categoryId: String): List<Phrase>
+
+    suspend fun phraseSpoken(phraseId: Long)
+
+    suspend fun deletePhrase(phraseId: Long)
+
+    suspend fun updatePhrase(phraseId: Long, localizedUtterance: LocalesWithText)
+
+    suspend fun addPhrase(localizedUtterance: LocalesWithText, parentCategoryId: String)
+}

--- a/app/src/main/java/com/willowtree/vocable/PhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/PhrasesUseCase.kt
@@ -9,36 +9,36 @@ import com.willowtree.vocable.utils.DateProvider
 import com.willowtree.vocable.utils.locale.LocalesWithText
 
 class PhrasesUseCase(
-    private val presetsRepository: ILegacyCategoriesAndPhrasesRepository,
-    private val dateProvider: DateProvider
-) {
-    suspend fun getPhrasesForCategory(categoryId: String): List<Phrase> {
+    private val legacyPhrasesRepository: ILegacyCategoriesAndPhrasesRepository,
+    private val dateProvider: DateProvider,
+) : IPhrasesUseCase {
+    override suspend fun getPhrasesForCategory(categoryId: String): List<Phrase> {
         if (categoryId == PresetCategories.RECENTS.id) {
-            return presetsRepository.getRecentPhrases().map { it.asPhrase() }
+            return legacyPhrasesRepository.getRecentPhrases().map { it.asPhrase() }
         }
-        return presetsRepository.getPhrasesForCategory(categoryId).map { it.asPhrase() }
+        return legacyPhrasesRepository.getPhrasesForCategory(categoryId).map { it.asPhrase() }
     }
 
-    suspend fun phraseSpoken(phraseId: Long) {
-        presetsRepository.updatePhraseLastSpoken(phraseId, dateProvider.currentTimeMillis())
+    override suspend fun phraseSpoken(phraseId: Long) {
+        legacyPhrasesRepository.updatePhraseLastSpoken(phraseId, dateProvider.currentTimeMillis())
     }
 
-    suspend fun deletePhrase(phraseId: Long) {
-        presetsRepository.deletePhrase(phraseId)
+    override suspend fun deletePhrase(phraseId: Long) {
+        legacyPhrasesRepository.deletePhrase(phraseId)
     }
 
-    suspend fun updatePhrase(phraseId: Long, localizedUtterance: LocalesWithText) {
-        presetsRepository.updatePhrase(phraseId, localizedUtterance)
+    override suspend fun updatePhrase(phraseId: Long, localizedUtterance: LocalesWithText) {
+        legacyPhrasesRepository.updatePhrase(phraseId, localizedUtterance)
     }
 
-    suspend fun addPhrase(localizedUtterance: LocalesWithText, parentCategoryId: String) {
-        presetsRepository.addPhrase(PhraseDto(
+    override suspend fun addPhrase(localizedUtterance: LocalesWithText, parentCategoryId: String) {
+        legacyPhrasesRepository.addPhrase(PhraseDto(
             phraseId = 0L,
             parentCategoryId = parentCategoryId,
             creationDate = dateProvider.currentTimeMillis(),
             lastSpokenDate = null,
             localizedUtterance = localizedUtterance,
-            sortOrder = presetsRepository.getPhrasesForCategory(parentCategoryId).size
+            sortOrder = legacyPhrasesRepository.getPhrasesForCategory(parentCategoryId).size
         ))
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhraseDto.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhraseDto.kt
@@ -1,0 +1,18 @@
+package com.willowtree.vocable.room
+
+import android.os.Parcelable
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import kotlinx.parcelize.Parcelize
+
+@Entity(tableName = "PresetPhrase")
+@Parcelize
+data class PresetPhraseDto(
+    @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "phrase_id") val phraseId: Long,
+    @ColumnInfo(name = "parent_category_id") val parentCategoryId: String?,
+    @ColumnInfo(name = "creation_date") val creationDate: Long,
+    @ColumnInfo(name = "last_spoken_date") val lastSpokenDate: Long?,
+    @ColumnInfo(name = "sort_order") val sortOrder: Int,
+    @ColumnInfo(name = "utterance_string_res") val utteranceStringRes: Int,
+) : Parcelable

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesDao.kt
@@ -1,0 +1,12 @@
+package com.willowtree.vocable.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+
+@Dao
+interface PresetPhrasesDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPhrase(phrase: PresetPhraseDto)
+}

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesRepository.kt
@@ -1,0 +1,7 @@
+package com.willowtree.vocable.room
+
+// TODO: MPV #467- this will take over the responsibilities for storing and fetching preset
+//                 phrases from the [ILegacyCategoriesAndPhrasesRepository]
+interface PresetPhrasesRepository {
+    suspend fun addPhrase(phrase: PresetPhraseDto)
+}

--- a/app/src/main/java/com/willowtree/vocable/room/RoomPresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/RoomPresetPhrasesRepository.kt
@@ -1,0 +1,9 @@
+package com.willowtree.vocable.room
+
+class RoomPresetPhrasesRepository(
+    private val database: VocableDatabase
+) : PresetPhrasesRepository {
+    override suspend fun addPhrase(phrase: PresetPhraseDto) {
+        database.presetPhrasesDao().insertPhrase(phrase)
+    }
+}

--- a/app/src/main/java/com/willowtree/vocable/room/RoomStoredPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/RoomStoredPhrasesRepository.kt
@@ -1,0 +1,9 @@
+package com.willowtree.vocable.room
+
+class RoomStoredPhrasesRepository(
+    private val database: VocableDatabase
+) : StoredPhrasesRepository {
+    override suspend fun addPhrase(phrase: PhraseDto) {
+        database.phraseDao().insertPhrase(phrase)
+    }
+}

--- a/app/src/main/java/com/willowtree/vocable/room/StoredPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/StoredPhrasesRepository.kt
@@ -1,0 +1,7 @@
+package com.willowtree.vocable.room
+
+// TODO: MPV #467- this will take over the responsibilities for storing and fetching stored
+//                 phrases from the [ILegacyCategoriesAndPhrasesRepository]
+interface StoredPhrasesRepository {
+    suspend fun addPhrase(phrase: PhraseDto)
+}

--- a/app/src/main/java/com/willowtree/vocable/room/VocableDatabase.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/VocableDatabase.kt
@@ -8,7 +8,12 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 
 @Database(
-    entities = [CategoryDto::class, PhraseDto::class, PresetCategoryDto::class],
+    entities = [
+        CategoryDto::class,
+        PhraseDto::class,
+        PresetCategoryDto::class,
+        PresetPhraseDto::class
+    ],
     version = 7,
     // TODO: PK - May be able to consolidate 6 and 7 since we never released 6
     autoMigrations = [AutoMigration(from = 6, to = 7)]
@@ -40,6 +45,8 @@ abstract class VocableDatabase : RoomDatabase() {
     abstract fun categoryDao(): CategoryDao
 
     abstract fun phraseDao(): PhraseDao
+
+    abstract fun presetPhrasesDao(): PresetPhrasesDao
 
     abstract fun presetCategoryDao(): PresetCategoryDao
 }


### PR DESCRIPTION
Creates a new table for PresetPhraseDto, and creates classes which will be responsible for preset/stored phrase editing/consumption. This will allow us to use a schema for preset phrases with resource IDs, avoiding workarounds that add tech debt to the app.

None of the changes here should affect the existing functionality in the app. The only exception is changes to the DB schema- we have agreed to hold off on writing migrations until we better understand what our schema will be at next release- to prevent ourselves from wasting time writing temporary workarounds.

Part of the work for #467. Following this MR we will:
 * Populate the PresetsDB using resource IDs to have translations that _just work_