### PR TITLE
Populate the New Preset Phrases Table

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
@@ -1,0 +1,74 @@
+package com.willowtree.vocable.presets
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.willowtree.vocable.room.RoomPresetPhrasesRepository
+import com.willowtree.vocable.room.VocableDatabase
+import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RoomPresetPhrasesRepositoryTest {
+    private fun createRepository(): RoomPresetPhrasesRepository {
+        return RoomPresetPhrasesRepository(
+            database = Room.inMemoryDatabaseBuilder(
+                ApplicationProvider.getApplicationContext(),
+                VocableDatabase::class.java
+            ).build()
+        )
+    }
+
+    private val resources = ApplicationProvider.getApplicationContext<Context>().resources
+
+    @Test
+    fun preset_phrases_populated() = runTest {
+        val repository = createRepository()
+
+        repository.populateDatabase()
+
+        val expectedPhrases = makePresetPhrases()
+        assertEquals(
+            expectedPhrases,
+            repository.getAllPresetPhrases()
+        )
+    }
+
+    @Test
+    fun given_populateDatabase_called_twice_no_duplicate_phrases_are_added()= runTest {
+        val repository = createRepository()
+
+        repository.populateDatabase()
+        repository.populateDatabase()
+
+        val expectedPhrases = makePresetPhrases()
+        assertEquals(
+            expectedPhrases,
+            repository.getAllPresetPhrases()
+        )
+    }
+
+    private fun makePresetPhrases(): List<PresetPhrase> {
+        return PresetCategories.values()
+            .filterNot { it == PresetCategories.MY_SAYINGS || it == PresetCategories.RECENTS }
+            .flatMap { presetCategory ->
+                val phrasesIds = resources.obtainTypedArray(presetCategory.getArrayId())
+                val expectedPhrases = mutableListOf<PresetPhrase>()
+                for (index in 0 until phrasesIds.length()) {
+                    val phraseId = phrasesIds.getResourceId(index, 0)
+                    val phraseEntryName = resources.getResourceEntryName(phraseId)
+                    expectedPhrases.add(
+                        PresetPhrase(
+                            phraseId = phraseEntryName,
+                            sortOrder = index,
+                        )
+                    )
+                }
+                phrasesIds.recycle()
+                expectedPhrases
+            }
+    }
+}

--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -65,7 +65,7 @@ object AppKoinModule {
         single { VocableSharedPreferences() } bind IVocableSharedPreferences::class
         single { LegacyCategoriesAndPhrasesRepository(get(), get()) } bind ILegacyCategoriesAndPhrasesRepository::class
         single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
-        single { LocalizedResourceUtility(androidContext().resources) } bind ILocalizedResourceUtility::class
+        single { LocalizedResourceUtility(androidContext()) } bind ILocalizedResourceUtility::class
         single { CategoriesUseCase(get(), get(), get(), get()) } bind ICategoriesUseCase::class
         single { PhrasesUseCase(get(), get()) }
         single { RandomUUIDProvider() } bind UUIDProvider::class

--- a/app/src/main/java/com/willowtree/vocable/IPhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/IPhrasesUseCase.kt
@@ -7,11 +7,11 @@ interface IPhrasesUseCase {
 
     suspend fun getPhrasesForCategory(categoryId: String): List<Phrase>
 
-    suspend fun phraseSpoken(phraseId: Long)
+    suspend fun phraseSpoken(phraseId: String)
 
-    suspend fun deletePhrase(phraseId: Long)
+    suspend fun deletePhrase(phraseId: String)
 
-    suspend fun updatePhrase(phraseId: Long, localizedUtterance: LocalesWithText)
+    suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText)
 
     suspend fun addPhrase(localizedUtterance: LocalesWithText, parentCategoryId: String)
 }

--- a/app/src/main/java/com/willowtree/vocable/PhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/PhrasesUseCase.kt
@@ -19,15 +19,15 @@ class PhrasesUseCase(
         return legacyPhrasesRepository.getPhrasesForCategory(categoryId).map { it.asPhrase() }
     }
 
-    override suspend fun phraseSpoken(phraseId: Long) {
+    override suspend fun phraseSpoken(phraseId: String) {
         legacyPhrasesRepository.updatePhraseLastSpoken(phraseId, dateProvider.currentTimeMillis())
     }
 
-    override suspend fun deletePhrase(phraseId: Long) {
+    override suspend fun deletePhrase(phraseId: String) {
         legacyPhrasesRepository.deletePhrase(phraseId)
     }
 
-    override suspend fun updatePhrase(phraseId: Long, localizedUtterance: LocalesWithText) {
+    override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText) {
         legacyPhrasesRepository.updatePhrase(phraseId, localizedUtterance)
     }
 

--- a/app/src/main/java/com/willowtree/vocable/presets/ILegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/ILegacyCategoriesAndPhrasesRepository.kt
@@ -20,13 +20,13 @@ interface ILegacyCategoriesAndPhrasesRepository {
      * Return all categories, sorted by [CategoryDto.sortOrder]
      */
     suspend fun getAllCategories(): List<CategoryDto>
-    suspend fun deletePhrase(phraseId: Long)
+    suspend fun deletePhrase(phraseId: String)
     suspend fun updateCategorySortOrders(categorySortOrders: List<CategorySortOrder>)
     suspend fun updateCategoryName(categoryId: String, localizedName: LocalesWithText)
     suspend fun updateCategoryHidden(categoryId: String, hidden: Boolean)
     suspend fun deleteCategory(categoryId: String)
     suspend fun getRecentPhrases(): List<PhraseDto>
-    suspend fun updatePhraseLastSpoken(phraseId: Long, lastSpokenDate: Long)
-    suspend fun updatePhrase(phraseId: Long, localizedUtterance: LocalesWithText)
+    suspend fun updatePhraseLastSpoken(phraseId: String, lastSpokenDate: Long)
+    suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText)
     suspend fun addPhrase(phrase: PhraseDto)
 }

--- a/app/src/main/java/com/willowtree/vocable/presets/LegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/LegacyCategoriesAndPhrasesRepository.kt
@@ -42,7 +42,7 @@ class LegacyCategoriesAndPhrasesRepository(
         database.phraseDao().insertPhrases(*phrases.toTypedArray())
     }
 
-    override suspend fun deletePhrase(phraseId: Long) {
+    override suspend fun deletePhrase(phraseId: String) {
         database.phraseDao().deletePhrase(phraseId)
     }
 
@@ -58,12 +58,12 @@ class LegacyCategoriesAndPhrasesRepository(
         database.categoryDao().deleteCategory(categoryId)
     }
 
-    override suspend fun updatePhrase(phraseId: Long, localizedUtterance: LocalesWithText) {
+    override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText) {
         database.phraseDao()
             .updatePhraseLocalizedUtterance(PhraseLocalizedUtterance(phraseId, localizedUtterance))
     }
 
-    override suspend fun updatePhraseLastSpoken(phraseId: Long, lastSpokenDate: Long) {
+    override suspend fun updatePhraseLastSpoken(phraseId: String, lastSpokenDate: Long) {
         database.phraseDao().updatePhraseSpokenDate(PhraseSpokenDate(phraseId, lastSpokenDate))
     }
 
@@ -83,8 +83,6 @@ class LegacyCategoriesAndPhrasesRepository(
                     get<Context>().resources.obtainTypedArray(presetCategory.getArrayId())
                 val phraseObjects = mutableListOf<PhraseDto>()
                 for (index in 0 until phrasesIds.length()) {
-                    // TODO: MPV #467- We will populate via a new table for preset phrases here
-                    //                 instead once we have the new table created
                     phraseObjects.add(
                         PhraseDto(
                             phraseId = 0L,

--- a/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
@@ -1,46 +1,56 @@
 package com.willowtree.vocable.presets
 
-import android.content.res.Resources
+import android.content.Context
 import android.os.Parcelable
 import com.willowtree.vocable.room.PhraseDto
+import com.willowtree.vocable.room.PresetPhraseDto
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import com.willowtree.vocable.utils.locale.text
 import kotlinx.parcelize.Parcelize
 
-sealed class Phrase : Parcelable {
-    abstract val phraseId: Long
-    abstract val sortOrder: Int
-
-    abstract fun text(resources: Resources): String
+sealed interface Phrase : Parcelable {
+    val phraseId: String
+    val sortOrder: Int
+    fun text(context: Context): String
 }
 
 @Parcelize
 data class CustomPhrase(
-    override val phraseId: Long,
+    override val phraseId: String,
     override val sortOrder: Int,
     val localizedUtterance: LocalesWithText?,
-) : Phrase(), Parcelable {
+) : Phrase, Parcelable {
 
-    override fun text(resources: Resources): String {
+    override fun text(context: Context): String {
         return localizedUtterance?.localizedText?.text() ?: ""
     }
 }
 
 @Parcelize
 data class PresetPhrase(
-    override val phraseId: Long,
+    override val phraseId: String,
     override val sortOrder: Int,
-    val utteranceStringRes: Int,
-) : Phrase() {
+) : Phrase {
 
-    override fun text(resources: Resources): String {
-        return resources.getString(utteranceStringRes)
+    override fun text(context: Context): String {
+        val utteranceStringRes = context.resources.getIdentifier(
+            /* name = */ phraseId,
+            /* defType = */ "string",
+            /* defPackage = */ context.packageName
+        )
+        return context.resources.getString(utteranceStringRes)
     }
 }
 
 fun PhraseDto.asPhrase(): Phrase =
     CustomPhrase(
-        phraseId,
+        phraseId.toString(),
         sortOrder,
         localizedUtterance,
+    )
+
+fun PresetPhraseDto.asPhrase(): PresetPhrase =
+    PresetPhrase(
+        phraseId = phraseId,
+        sortOrder = sortOrder,
     )

--- a/app/src/main/java/com/willowtree/vocable/room/PhraseDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PhraseDao.kt
@@ -12,7 +12,7 @@ interface PhraseDao {
     suspend fun insertPhrases(vararg phrases: PhraseDto)
 
     @Query("DELETE FROM Phrase WHERE phrase_id == :phraseId")
-    suspend fun deletePhrase(phraseId: Long)
+    suspend fun deletePhrase(phraseId: String)
 
     @Delete
     suspend fun deletePhrases(vararg phrases: PhraseDto)

--- a/app/src/main/java/com/willowtree/vocable/room/PhraseDto.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PhraseDto.kt
@@ -7,8 +7,6 @@ import androidx.room.PrimaryKey
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import kotlinx.parcelize.Parcelize
 
-// TODO: MPV- this will become the table for exclusively custom phrases, and we will create a new,
-//            separate table for the presets. Upcoming MR will handle this
 @Entity(tableName = "Phrase")
 @Parcelize
 data class PhraseDto(

--- a/app/src/main/java/com/willowtree/vocable/room/PhraseLocalizedUtterance.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PhraseLocalizedUtterance.kt
@@ -4,6 +4,6 @@ import androidx.room.ColumnInfo
 import com.willowtree.vocable.utils.locale.LocalesWithText
 
 data class PhraseLocalizedUtterance(
-    @ColumnInfo(name = "phrase_id") val phraseId: Long,
+    @ColumnInfo(name = "phrase_id") val phraseId: String,
     @ColumnInfo(name = "localized_utterance") var localizedUtterance: LocalesWithText
 )

--- a/app/src/main/java/com/willowtree/vocable/room/PhraseSpokenDate.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PhraseSpokenDate.kt
@@ -3,6 +3,6 @@ package com.willowtree.vocable.room
 import androidx.room.ColumnInfo
 
 data class PhraseSpokenDate(
-    @ColumnInfo(name = "phrase_id") val phraseId: Long,
+    @ColumnInfo(name = "phrase_id") val phraseId: String,
     @ColumnInfo(name = "last_spoken_date") val lastSpokenDate: Long
 )

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhraseDto.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhraseDto.kt
@@ -9,10 +9,9 @@ import kotlinx.parcelize.Parcelize
 @Entity(tableName = "PresetPhrase")
 @Parcelize
 data class PresetPhraseDto(
-    @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "phrase_id") val phraseId: Long,
+    @PrimaryKey @ColumnInfo(name = "phrase_id") val phraseId: String,
     @ColumnInfo(name = "parent_category_id") val parentCategoryId: String?,
     @ColumnInfo(name = "creation_date") val creationDate: Long,
     @ColumnInfo(name = "last_spoken_date") val lastSpokenDate: Long?,
     @ColumnInfo(name = "sort_order") val sortOrder: Int,
-    @ColumnInfo(name = "utterance_string_res") val utteranceStringRes: Int,
 ) : Parcelable

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesDao.kt
@@ -3,10 +3,14 @@ package com.willowtree.vocable.room
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
+import androidx.room.Query
 
 @Dao
 interface PresetPhrasesDao {
 
+    @Query("SELECT * FROM PresetPhrase")
+    suspend fun getAllPresetPhrases(): List<PresetPhraseDto>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertPhrase(phrase: PresetPhraseDto)
+    suspend fun insertPhrases(phrases: List<PresetPhraseDto>)
 }

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesRepository.kt
@@ -1,7 +1,8 @@
 package com.willowtree.vocable.room
 
-// TODO: MPV #467- this will take over the responsibilities for storing and fetching preset
-//                 phrases from the [ILegacyCategoriesAndPhrasesRepository]
+import com.willowtree.vocable.presets.PresetPhrase
+
 interface PresetPhrasesRepository {
-    suspend fun addPhrase(phrase: PresetPhraseDto)
+    suspend fun populateDatabase()
+    suspend fun getAllPresetPhrases(): List<PresetPhrase>
 }

--- a/app/src/main/java/com/willowtree/vocable/room/RoomPresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/RoomPresetPhrasesRepository.kt
@@ -1,9 +1,62 @@
 package com.willowtree.vocable.room
 
+import android.content.Context
+import com.willowtree.vocable.presets.PresetCategories
+import com.willowtree.vocable.presets.PresetPhrase
+import com.willowtree.vocable.presets.asPhrase
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.koin.core.context.GlobalContext.get
+
 class RoomPresetPhrasesRepository(
-    private val database: VocableDatabase
+    private val database: VocableDatabase,
 ) : PresetPhrasesRepository {
-    override suspend fun addPhrase(phrase: PresetPhraseDto) {
-        database.presetPhrasesDao().insertPhrase(phrase)
+
+    private val phrasesMutex = Mutex()
+
+    override suspend fun populateDatabase() {
+        ensurePopulated()
+    }
+
+    override suspend fun getAllPresetPhrases(): List<PresetPhrase> {
+        return database.presetPhrasesDao().getAllPresetPhrases()
+            .map(PresetPhraseDto::asPhrase)
+    }
+
+    private suspend fun ensurePopulated() {
+        phrasesMutex.withLock {
+            val existingPresetPhrases = database.presetPhrasesDao().getAllPresetPhrases()
+            val existingResourceIdStrings = existingPresetPhrases.map { it.phraseId }.toSet()
+
+            PresetCategories.values().forEach { presetCategory ->
+                if (presetCategory != PresetCategories.RECENTS && presetCategory != PresetCategories.MY_SAYINGS) {
+                    val phrasesIds = get().get<Context>()
+                        .resources.obtainTypedArray(presetCategory.getArrayId())
+                    val phraseObjects = mutableListOf<PresetPhraseDto>()
+                    for (index in 0 until phrasesIds.length()) {
+                        val phraseId = phrasesIds.getResourceId(index, 0)
+                        val phraseEntryName =
+                            get().get<Context>().resources.getResourceEntryName(phraseId)
+                        if (phraseEntryName !in existingResourceIdStrings) {
+                            phraseObjects.add(
+                                PresetPhraseDto(
+                                    phraseId = phraseEntryName,
+                                    parentCategoryId = presetCategory.id,
+                                    creationDate = System.currentTimeMillis(),
+                                    lastSpokenDate = null,
+                                    sortOrder = phraseObjects.size,
+                                )
+                            )
+                        }
+                    }
+                    phrasesIds.recycle()
+                    addPhrases(phraseObjects)
+                }
+            }
+        }
+    }
+
+    private suspend fun addPhrases(presetPhrases: List<PresetPhraseDto>) {
+        database.presetPhrasesDao().insertPhrases(presetPhrases)
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/room/models/PresetPhrase.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/models/PresetPhrase.kt
@@ -1,7 +1,0 @@
-package com.willowtree.vocable.room.models
-
-data class PresetPhrase(
-    val id: String,
-    val categoryIds: List<String>,
-    val localizedUtterance: Map<String, String>
-)

--- a/app/src/main/java/com/willowtree/vocable/room/models/PresetsObject.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/models/PresetsObject.kt
@@ -1,7 +1,0 @@
-package com.willowtree.vocable.room.models
-
-data class PresetsObject(
-    val schemaVersion: Int,
-    val phrases: List<PresetPhrase>,
-    val categories: List<PresetCategory>
-)

--- a/app/src/main/java/com/willowtree/vocable/settings/EditPhrasesViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditPhrasesViewModel.kt
@@ -17,7 +17,7 @@ class EditPhrasesViewModel : ViewModel(), KoinComponent {
     private val liveShowPhraseAdded = MutableLiveData<Boolean>()
     val showPhraseAdded: LiveData<Boolean> = liveShowPhraseAdded
 
-    fun updatePhrase(phraseId: Long, localizedUtterance: LocalesWithText) {
+    fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText) {
         viewModelScope.launch {
             phrasesUseCase.updatePhrase(phraseId, localizedUtterance)
             liveShowPhraseAdded.postValue(true)

--- a/app/src/main/java/com/willowtree/vocable/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/splash/SplashViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.presets.LegacyCategoriesAndPhrasesRepository
+import com.willowtree.vocable.room.RoomPresetPhrasesRepository
 import com.willowtree.vocable.utils.VocableSharedPreferences
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -13,6 +14,8 @@ import org.koin.core.component.inject
 class SplashViewModel : ViewModel(), KoinComponent {
 
     private val presetsRepository: LegacyCategoriesAndPhrasesRepository by inject()
+
+    private val newPresetsRepository: RoomPresetPhrasesRepository by inject()
 
     private val sharedPrefs: VocableSharedPreferences by inject()
 
@@ -27,6 +30,7 @@ class SplashViewModel : ViewModel(), KoinComponent {
         viewModelScope.launch {
             if (sharedPrefs.getFirstTime()) {
                 presetsRepository.populateDatabase()
+                newPresetsRepository.populateDatabase()
                 sharedPrefs.setFirstTime()
             }
 

--- a/app/src/main/java/com/willowtree/vocable/utils/locale/LocalizedResourceUtility.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/locale/LocalizedResourceUtility.kt
@@ -1,19 +1,19 @@
 package com.willowtree.vocable.utils.locale
 
-import android.content.res.Resources
+import android.content.Context
 import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.presets.Phrase
 import com.willowtree.vocable.utils.ILocalizedResourceUtility
 import org.koin.core.component.KoinComponent
 
 class LocalizedResourceUtility(
-    val resources: Resources
+    private val context: Context,
 ) : KoinComponent, ILocalizedResourceUtility {
 
     override fun getTextFromCategory(category: Category?): String {
         return category?.localizedName?.localizedText?.text() ?: category?.resourceId?.let {
             if (it != 0) {
-                resources.getString(it)
+                context.resources.getString(it)
             } else {
                 ""
             }
@@ -21,6 +21,6 @@ class LocalizedResourceUtility(
     }
 
     fun getTextFromPhrase(phrase: Phrase?): String {
-        return phrase?.text(resources) ?: ""
+        return phrase?.text(context) ?: ""
     }
 }

--- a/app/src/test/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -38,7 +38,7 @@ class PhrasesUseCaseTest {
         assertEquals(
             listOf(
                 CustomPhrase(
-                    phraseId = 1L,
+                    phraseId = "1",
                     localizedUtterance = testLocalesWithText,
                     sortOrder = 0
                 )
@@ -66,7 +66,7 @@ class PhrasesUseCaseTest {
         assertEquals(
             listOf(
                 CustomPhrase(
-                    phraseId = 1L,
+                    phraseId = "1",
                     localizedUtterance = testLocalesWithText,
                     sortOrder = 0
                 )

--- a/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
@@ -60,7 +60,7 @@ class FakeLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
         return _allCategories.value.sortedBy { it.sortOrder }
     }
 
-    override suspend fun deletePhrase(phraseId: Long) {
+    override suspend fun deletePhrase(phraseId: String) {
         TODO("Not yet implemented")
     }
 
@@ -102,11 +102,11 @@ class FakeLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
     }
 
     override suspend fun getRecentPhrases(): List<PhraseDto> = _recentPhrases
-    override suspend fun updatePhraseLastSpoken(phraseId: Long, lastSpokenDate: Long) {
+    override suspend fun updatePhraseLastSpoken(phraseId: String, lastSpokenDate: Long) {
         TODO("Not yet implemented")
     }
 
-    override suspend fun updatePhrase(phraseId: Long, localizedUtterance: LocalesWithText) {
+    override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText) {
         TODO("Not yet implemented")
     }
 

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -154,7 +154,7 @@ class PresetsViewModelTest {
         assertEquals(
             listOf(
                 CustomPhrase(
-                    phraseId = 2L,
+                    phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0
                 ),
@@ -203,12 +203,12 @@ class PresetsViewModelTest {
         assertEquals(
             listOf(
                 CustomPhrase(
-                    phraseId = 2L,
+                    phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0
                 ),
                 CustomPhrase(
-                    phraseId = 1L,
+                    phraseId = "1",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Hello")),
                     sortOrder = 1
                 ),
@@ -255,12 +255,12 @@ class PresetsViewModelTest {
         assertEquals(
             listOf(
                 CustomPhrase(
-                    phraseId = 1L,
+                    phraseId = "1",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Hello")),
                     sortOrder = 1
                 ),
                 CustomPhrase(
-                    phraseId = 2L,
+                    phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0
                 )


### PR DESCRIPTION
Populates the new preset phrases table at app launch. The new table is still not consumed anywhere. The old table has not been changed.

Also changes the preset phrases table to store a PresetPhraseUtterance enum instead of a resource ID directly as resource IDs are unstable 😳 This will replace the usage of arrays.xml once we stop using the old table