### PR TITLE
Handle Updating Last Spoken Time Across Preset/Stored Tables

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -4,7 +4,6 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.willowtree.vocable.presets.PresetCategories
-import com.willowtree.vocable.presets.asPhrase
 import com.willowtree.vocable.room.PhraseDto
 import com.willowtree.vocable.room.RoomPresetPhrasesRepository
 import com.willowtree.vocable.room.RoomStoredPhrasesRepository
@@ -43,6 +42,8 @@ class PhrasesUseCaseTest {
         )
     }
 
+    // TODO: Update this test to rely on getPresetPhrasesForCategory(Recents) instead of directly
+    //       once that has been updated to handle both preset and stored phrases
     @Test
     fun phrase_spoken_updates_stored_and_preset() = runTest {
         val useCase = createUseCase()
@@ -65,15 +66,14 @@ class PhrasesUseCaseTest {
 
         assertEquals(
             123L,
-            presetPhrasesRepository.getAllPresetPhrases()
+            database.presetPhrasesDao().getAllPresetPhrases()
                 .first { it.phraseId == "category_123_0" }
                 .lastSpokenDate
         )
         assertEquals(
             456L,
             database.phraseDao().getPhrasesForCategory(PresetCategories.GENERAL.id)
-                .map { it.asPhrase() }
-                .first { it.phraseId == "1" }
+                .first { it.phraseId == 1L }
                 .lastSpokenDate
         )
     }

--- a/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -1,0 +1,80 @@
+package com.willowtree.vocable
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.willowtree.vocable.presets.PresetCategories
+import com.willowtree.vocable.presets.asPhrase
+import com.willowtree.vocable.room.PhraseDto
+import com.willowtree.vocable.room.RoomPresetPhrasesRepository
+import com.willowtree.vocable.room.RoomStoredPhrasesRepository
+import com.willowtree.vocable.room.VocableDatabase
+import com.willowtree.vocable.utility.FakeDateProvider
+import com.willowtree.vocable.utility.StubLegacyCategoriesAndPhrasesRepository
+import com.willowtree.vocable.utils.locale.LocalesWithText
+import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4::class)
+class PhrasesUseCaseTest {
+
+    private val database = Room.inMemoryDatabaseBuilder(
+        ApplicationProvider.getApplicationContext(),
+        VocableDatabase::class.java
+    ).build()
+
+    private val dateProvider = FakeDateProvider()
+    private val presetPhrasesRepository = RoomPresetPhrasesRepository(database, dateProvider)
+    private val storedPhrasesRepository = RoomStoredPhrasesRepository(database, dateProvider)
+    private val legacyRepository = StubLegacyCategoriesAndPhrasesRepository()
+    private val testLocalesWithText = LocalesWithText(
+        mapOf("en" to "text")
+    )
+
+    private fun createUseCase(): PhrasesUseCase {
+        return PhrasesUseCase(
+            legacyPhrasesRepository = legacyRepository,
+            storedPhrasesRepository = storedPhrasesRepository,
+            presetPhrasesRepository = presetPhrasesRepository,
+            dateProvider = FakeDateProvider()
+        )
+    }
+
+    @Test
+    fun phrase_spoken_updates_stored_and_preset() = runTest {
+        val useCase = createUseCase()
+        presetPhrasesRepository.populateDatabase()
+        storedPhrasesRepository.addPhrase(
+            PhraseDto(
+                phraseId = 1L,
+                localizedUtterance = testLocalesWithText,
+                parentCategoryId = PresetCategories.GENERAL.id,
+                creationDate = 0L,
+                lastSpokenDate = 100L,
+                sortOrder = 0
+            )
+        )
+
+        dateProvider.time = 123L
+        useCase.updatePhraseLastSpokenTime("category_123_0")
+        dateProvider.time = 456L
+        useCase.updatePhraseLastSpokenTime("1")
+
+        assertEquals(
+            123L,
+            presetPhrasesRepository.getAllPresetPhrases()
+                .first { it.phraseId == "category_123_0" }
+                .lastSpokenDate
+        )
+        assertEquals(
+            456L,
+            database.phraseDao().getPhrasesForCategory(PresetCategories.GENERAL.id)
+                .map { it.asPhrase() }
+                .first { it.phraseId == "1" }
+                .lastSpokenDate
+        )
+    }
+}

--- a/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.willowtree.vocable.room.RoomPresetPhrasesRepository
 import com.willowtree.vocable.room.VocableDatabase
+import com.willowtree.vocable.utility.FakeDateProvider
 import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -18,7 +19,8 @@ class RoomPresetPhrasesRepositoryTest {
             database = Room.inMemoryDatabaseBuilder(
                 ApplicationProvider.getApplicationContext(),
                 VocableDatabase::class.java
-            ).build()
+            ).build(),
+            dateProvider = FakeDateProvider()
         )
     }
 
@@ -64,6 +66,7 @@ class RoomPresetPhrasesRepositoryTest {
                         PresetPhrase(
                             phraseId = phraseEntryName,
                             sortOrder = index,
+                            lastSpokenDate = null,
                         )
                     )
                 }

--- a/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
@@ -66,7 +66,6 @@ class RoomPresetPhrasesRepositoryTest {
                         PresetPhrase(
                             phraseId = phraseEntryName,
                             sortOrder = index,
-                            lastSpokenDate = null,
                         )
                     )
                 }

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/FakeDateProvider.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/FakeDateProvider.kt
@@ -1,0 +1,12 @@
+package com.willowtree.vocable.utility
+
+import com.willowtree.vocable.utils.DateProvider
+
+class FakeDateProvider : DateProvider {
+
+    var time = 0L
+
+    override fun currentTimeMillis(): Long {
+        return time
+    }
+}

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/StubLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/StubLegacyCategoriesAndPhrasesRepository.kt
@@ -1,0 +1,42 @@
+package com.willowtree.vocable.utility
+
+import com.willowtree.vocable.presets.ILegacyCategoriesAndPhrasesRepository
+import com.willowtree.vocable.room.CategorySortOrder
+import com.willowtree.vocable.room.PhraseDto
+import com.willowtree.vocable.utils.locale.LocalesWithText
+
+
+// Stub for legacy categories/phrases repository. We are using this stub to test the transition of
+// PhrasesUseCase from using the legacy categories/phrases repository to using the room-based
+// stored and preset phrases repositories. This stub ensures that none of the behavior/data in the
+// legacy repository is accidentally used in the testing of newly refactored tests.
+class StubLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepository {
+    override suspend fun getPhrasesForCategory(categoryId: String) = error("Not implemented")
+
+    override fun getAllCategoriesFlow() = error("Not implemented")
+
+    override suspend fun getAllCategories() = error("Not implemented")
+
+    override suspend fun deletePhrase(phraseId: String) = error("Not implemented")
+
+    override suspend fun updateCategorySortOrders(categorySortOrders: List<CategorySortOrder>) =
+        error("Not implemented")
+
+    override suspend fun updateCategoryName(categoryId: String, localizedName: LocalesWithText)
+        = error("Not implemented")
+
+    override suspend fun updateCategoryHidden(categoryId: String, hidden: Boolean)
+        = error("Not implemented")
+
+    override suspend fun deleteCategory(categoryId: String) = error("Not implemented")
+
+    override suspend fun getRecentPhrases(): List<PhraseDto> = error("Not implemented")
+
+    override suspend fun updatePhraseLastSpoken(phraseId: String, lastSpokenDate: Long)
+        = error("Not implemented")
+
+    override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText)
+        = error("Not implemented")
+
+    override suspend fun addPhrase(phrase: PhraseDto) = error("Not implemented")
+}

--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -67,14 +67,14 @@ object AppKoinModule {
         single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
         single { LocalizedResourceUtility(androidContext()) } bind ILocalizedResourceUtility::class
         single { CategoriesUseCase(get(), get(), get(), get()) } bind ICategoriesUseCase::class
-        single { PhrasesUseCase(get(), get()) }
+        single { PhrasesUseCase(get(), get(), get(), get()) } bind IPhrasesUseCase::class
         single { RandomUUIDProvider() } bind UUIDProvider::class
         single { JavaDateProvider() } bind DateProvider::class
         single { JavaLocaleProvider() } bind LocaleProvider::class
         single { RoomStoredCategoriesRepository(get()) } bind StoredCategoriesRepository::class
         single { RoomPresetCategoriesRepository(get()) } bind PresetCategoriesRepository::class
-        single { RoomStoredPhrasesRepository(get()) } bind StoredPhrasesRepository::class
-        single { RoomPresetPhrasesRepository(get()) } bind PresetPhrasesRepository::class
+        single { RoomStoredPhrasesRepository(get(), get()) } bind StoredPhrasesRepository::class
+        single { RoomPresetPhrasesRepository(get(), get()) } bind PresetPhrasesRepository::class
         single { VocableDatabase.getVocableDatabase(get()) }
         viewModel { PresetsViewModel(get(), get()) }
         viewModel { EditCategoriesViewModel(get(), get(), get()) }

--- a/app/src/main/java/com/willowtree/vocable/IPhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/IPhrasesUseCase.kt
@@ -7,7 +7,7 @@ interface IPhrasesUseCase {
 
     suspend fun getPhrasesForCategory(categoryId: String): List<Phrase>
 
-    suspend fun phraseSpoken(phraseId: String)
+    suspend fun updatePhraseLastSpokenTime(phraseId: String)
 
     suspend fun deletePhrase(phraseId: String)
 

--- a/app/src/main/java/com/willowtree/vocable/PhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/PhrasesUseCase.kt
@@ -5,11 +5,15 @@ import com.willowtree.vocable.presets.Phrase
 import com.willowtree.vocable.presets.PresetCategories
 import com.willowtree.vocable.presets.asPhrase
 import com.willowtree.vocable.room.PhraseDto
+import com.willowtree.vocable.room.PresetPhrasesRepository
+import com.willowtree.vocable.room.StoredPhrasesRepository
 import com.willowtree.vocable.utils.DateProvider
 import com.willowtree.vocable.utils.locale.LocalesWithText
 
 class PhrasesUseCase(
     private val legacyPhrasesRepository: ILegacyCategoriesAndPhrasesRepository,
+    private val storedPhrasesRepository: StoredPhrasesRepository,
+    private val presetPhrasesRepository: PresetPhrasesRepository,
     private val dateProvider: DateProvider,
 ) : IPhrasesUseCase {
     override suspend fun getPhrasesForCategory(categoryId: String): List<Phrase> {
@@ -19,8 +23,9 @@ class PhrasesUseCase(
         return legacyPhrasesRepository.getPhrasesForCategory(categoryId).map { it.asPhrase() }
     }
 
-    override suspend fun phraseSpoken(phraseId: String) {
-        legacyPhrasesRepository.updatePhraseLastSpoken(phraseId, dateProvider.currentTimeMillis())
+    override suspend fun updatePhraseLastSpokenTime(phraseId: String) {
+        storedPhrasesRepository.updatePhraseLastSpokenTime(phraseId)
+        presetPhrasesRepository.updatePhraseLastSpokenTime(phraseId)
     }
 
     override suspend fun deletePhrase(phraseId: String) {

--- a/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
@@ -11,6 +11,7 @@ import kotlinx.parcelize.Parcelize
 sealed interface Phrase : Parcelable {
     val phraseId: String
     val sortOrder: Int
+    val lastSpokenDate: Long?
     fun text(context: Context): String
 }
 
@@ -19,6 +20,7 @@ data class CustomPhrase(
     override val phraseId: String,
     override val sortOrder: Int,
     val localizedUtterance: LocalesWithText?,
+    override val lastSpokenDate: Long?,
 ) : Phrase, Parcelable {
 
     override fun text(context: Context): String {
@@ -30,6 +32,7 @@ data class CustomPhrase(
 data class PresetPhrase(
     override val phraseId: String,
     override val sortOrder: Int,
+    override val lastSpokenDate: Long?,
 ) : Phrase {
 
     override fun text(context: Context): String {
@@ -44,13 +47,15 @@ data class PresetPhrase(
 
 fun PhraseDto.asPhrase(): Phrase =
     CustomPhrase(
-        phraseId.toString(),
-        sortOrder,
-        localizedUtterance,
+        phraseId = phraseId.toString(),
+        sortOrder = sortOrder,
+        localizedUtterance = localizedUtterance,
+        lastSpokenDate = lastSpokenDate,
     )
 
 fun PresetPhraseDto.asPhrase(): PresetPhrase =
     PresetPhrase(
         phraseId = phraseId,
         sortOrder = sortOrder,
+        lastSpokenDate = lastSpokenDate,
     )

--- a/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
@@ -11,7 +11,6 @@ import kotlinx.parcelize.Parcelize
 sealed interface Phrase : Parcelable {
     val phraseId: String
     val sortOrder: Int
-    val lastSpokenDate: Long?
     fun text(context: Context): String
 }
 
@@ -20,7 +19,6 @@ data class CustomPhrase(
     override val phraseId: String,
     override val sortOrder: Int,
     val localizedUtterance: LocalesWithText?,
-    override val lastSpokenDate: Long?,
 ) : Phrase, Parcelable {
 
     override fun text(context: Context): String {
@@ -32,7 +30,6 @@ data class CustomPhrase(
 data class PresetPhrase(
     override val phraseId: String,
     override val sortOrder: Int,
-    override val lastSpokenDate: Long?,
 ) : Phrase {
 
     override fun text(context: Context): String {
@@ -50,12 +47,10 @@ fun PhraseDto.asPhrase(): Phrase =
         phraseId = phraseId.toString(),
         sortOrder = sortOrder,
         localizedUtterance = localizedUtterance,
-        lastSpokenDate = lastSpokenDate,
     )
 
 fun PresetPhraseDto.asPhrase(): PresetPhrase =
     PresetPhrase(
         phraseId = phraseId,
         sortOrder = sortOrder,
-        lastSpokenDate = lastSpokenDate,
     )

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.ICategoriesUseCase
-import com.willowtree.vocable.PhrasesUseCase
+import com.willowtree.vocable.IPhrasesUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 
 class PresetsViewModel(
     categoriesUseCase: ICategoriesUseCase,
-    private val phrasesUseCase: PhrasesUseCase
+    private val phrasesUseCase: IPhrasesUseCase
 ) : ViewModel() {
 
     val categoryList: LiveData<List<Category>> = categoriesUseCase.categories().asLiveData()
@@ -67,7 +67,7 @@ class PresetsViewModel(
 
     fun addToRecents(phrase: Phrase) {
         viewModelScope.launch {
-            phrasesUseCase.phraseSpoken(phrase.phraseId)
+            phrasesUseCase.updatePhraseLastSpokenTime(phrase.phraseId)
         }
     }
 

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhraseDto.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhraseDto.kt
@@ -10,7 +10,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class PresetPhraseDto(
     @PrimaryKey @ColumnInfo(name = "phrase_id") val phraseId: String,
-    @ColumnInfo(name = "parent_category_id") val parentCategoryId: String?,
+    @ColumnInfo(name = "parent_category_id") val parentCategoryId: String,
     @ColumnInfo(name = "creation_date") val creationDate: Long,
     @ColumnInfo(name = "last_spoken_date") val lastSpokenDate: Long?,
     @ColumnInfo(name = "sort_order") val sortOrder: Int,

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 
 @Dao
 interface PresetPhrasesDao {
@@ -13,4 +14,7 @@ interface PresetPhrasesDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertPhrases(phrases: List<PresetPhraseDto>)
+
+    @Update(entity = PresetPhraseDto::class)
+    suspend fun updatePhraseSpokenDate(phraseSpokenDate: PhraseSpokenDate)
 }

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesRepository.kt
@@ -5,4 +5,5 @@ import com.willowtree.vocable.presets.PresetPhrase
 interface PresetPhrasesRepository {
     suspend fun populateDatabase()
     suspend fun getAllPresetPhrases(): List<PresetPhrase>
+    suspend fun updatePhraseLastSpokenTime(phraseId: String)
 }

--- a/app/src/main/java/com/willowtree/vocable/room/RoomPresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/RoomPresetPhrasesRepository.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import com.willowtree.vocable.presets.PresetCategories
 import com.willowtree.vocable.presets.PresetPhrase
 import com.willowtree.vocable.presets.asPhrase
+import com.willowtree.vocable.utils.DateProvider
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.koin.core.context.GlobalContext.get
 
 class RoomPresetPhrasesRepository(
     private val database: VocableDatabase,
+    private val dateProvider: DateProvider,
 ) : PresetPhrasesRepository {
 
     private val phrasesMutex = Mutex()
@@ -21,6 +23,15 @@ class RoomPresetPhrasesRepository(
     override suspend fun getAllPresetPhrases(): List<PresetPhrase> {
         return database.presetPhrasesDao().getAllPresetPhrases()
             .map(PresetPhraseDto::asPhrase)
+    }
+
+    override suspend fun updatePhraseLastSpokenTime(phraseId: String) {
+        database.presetPhrasesDao().updatePhraseSpokenDate(
+            PhraseSpokenDate(
+                phraseId = phraseId,
+                lastSpokenDate = dateProvider.currentTimeMillis()
+            )
+        )
     }
 
     private suspend fun ensurePopulated() {

--- a/app/src/main/java/com/willowtree/vocable/room/RoomStoredPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/RoomStoredPhrasesRepository.kt
@@ -1,9 +1,21 @@
 package com.willowtree.vocable.room
 
+import com.willowtree.vocable.utils.DateProvider
+
 class RoomStoredPhrasesRepository(
-    private val database: VocableDatabase
+    private val database: VocableDatabase,
+    private val dateProvider: DateProvider,
 ) : StoredPhrasesRepository {
     override suspend fun addPhrase(phrase: PhraseDto) {
         database.phraseDao().insertPhrase(phrase)
+    }
+
+    override suspend fun updatePhraseLastSpokenTime(phraseId: String) {
+        database.phraseDao().updatePhraseSpokenDate(
+            PhraseSpokenDate(
+                phraseId = phraseId,
+                lastSpokenDate = dateProvider.currentTimeMillis()
+            )
+        )
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/room/StoredPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/StoredPhrasesRepository.kt
@@ -4,4 +4,5 @@ package com.willowtree.vocable.room
 //                 phrases from the [ILegacyCategoriesAndPhrasesRepository]
 interface StoredPhrasesRepository {
     suspend fun addPhrase(phrase: PhraseDto)
+    suspend fun updatePhraseLastSpokenTime(phraseId: String)
 }

--- a/app/src/test/java/com/willowtree/vocable/LiveDataExt.kt
+++ b/app/src/test/java/com/willowtree/vocable/LiveDataExt.kt
@@ -13,7 +13,7 @@ fun <T> LiveData<T>.getOrAwaitValue(
     var data: T? = null
     val latch = CountDownLatch(1)
     val observer = object : Observer<T> {
-        override fun onChanged(o: T?) {
+        override fun onChanged(o: T) {
             data = o
             latch.countDown()
             this@getOrAwaitValue.removeObserver(this)

--- a/app/src/test/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -53,7 +53,6 @@ class PhrasesUseCaseTest {
                     phraseId = "1",
                     localizedUtterance = testLocalesWithText,
                     sortOrder = 0,
-                    lastSpokenDate = 0L,
                 )
             ),
             useCase.getPhrasesForCategory(PresetCategories.RECENTS.id)
@@ -82,7 +81,6 @@ class PhrasesUseCaseTest {
                     phraseId = "1",
                     localizedUtterance = testLocalesWithText,
                     sortOrder = 0,
-                    lastSpokenDate = 0L,
                 )
             ),
             useCase.getPhrasesForCategory("category")

--- a/app/src/test/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -4,12 +4,19 @@ import com.willowtree.vocable.presets.CustomPhrase
 import com.willowtree.vocable.presets.FakeLegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.PresetCategories
 import com.willowtree.vocable.room.PhraseDto
+import com.willowtree.vocable.room.PresetPhrasesRepository
+import com.willowtree.vocable.room.StoredPhrasesRepository
 import com.willowtree.vocable.utils.FakeDateProvider
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@Deprecated(
+    message = "Migrating to prefer androidTest/*/PhrasesUseCaseTest instead, as it is backed by a" +
+            " real room instance.",
+    replaceWith = ReplaceWith("androidTest/*/PhrasesUseCaseTest")
+)
 class PhrasesUseCaseTest {
 
     private val presetsRepository = FakeLegacyCategoriesAndPhrasesRepository()
@@ -18,7 +25,12 @@ class PhrasesUseCaseTest {
     )
 
     private fun createUseCase(): PhrasesUseCase {
-        return PhrasesUseCase(presetsRepository, FakeDateProvider())
+        return PhrasesUseCase(
+            legacyPhrasesRepository = presetsRepository,
+            storedPhrasesRepository = StubStoredPhrasesRepository(),
+            presetPhrasesRepository = StubPresetPhrasesRepository(),
+            dateProvider = FakeDateProvider(),
+        )
     }
 
     @Test
@@ -40,7 +52,8 @@ class PhrasesUseCaseTest {
                 CustomPhrase(
                     phraseId = "1",
                     localizedUtterance = testLocalesWithText,
-                    sortOrder = 0
+                    sortOrder = 0,
+                    lastSpokenDate = 0L,
                 )
             ),
             useCase.getPhrasesForCategory(PresetCategories.RECENTS.id)
@@ -68,11 +81,28 @@ class PhrasesUseCaseTest {
                 CustomPhrase(
                     phraseId = "1",
                     localizedUtterance = testLocalesWithText,
-                    sortOrder = 0
+                    sortOrder = 0,
+                    lastSpokenDate = 0L,
                 )
             ),
             useCase.getPhrasesForCategory("category")
         )
     }
 
+    // Temporary stubs for repositories- when we implement getPhrasesForCategory using the two
+    // separate preset/stored repositories, we should use the real impls and move these tests to
+    // androidTest/PhrasesUseCaseTest.
+    class StubPresetPhrasesRepository : PresetPhrasesRepository {
+        override suspend fun populateDatabase() = error("Not implemented")
+
+        override suspend fun getAllPresetPhrases() = error("Not implemented")
+
+        override suspend fun updatePhraseLastSpokenTime(phraseId: String) = error("Not implemented")
+    }
+
+    class StubStoredPhrasesRepository : StoredPhrasesRepository {
+        override suspend fun addPhrase(phrase: PhraseDto) = error("Not implemented")
+
+        override suspend fun updatePhraseLastSpokenTime(phraseId: String) = error("Not implemented")
+    }
 }

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -164,7 +164,6 @@ class PresetsViewModelTest {
                     phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0,
-                    lastSpokenDate = 0L,
                 ),
                 null
             ),
@@ -214,13 +213,11 @@ class PresetsViewModelTest {
                     phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0,
-                    lastSpokenDate = 0L,
                 ),
                 CustomPhrase(
                     phraseId = "1",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Hello")),
                     sortOrder = 1,
-                    lastSpokenDate = 0L,
                 ),
                 null
             ),
@@ -268,13 +265,11 @@ class PresetsViewModelTest {
                     phraseId = "1",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Hello")),
                     sortOrder = 1,
-                    lastSpokenDate = 0L,
                 ),
                 CustomPhrase(
                     phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0,
-                    lastSpokenDate = 0L,
                 )
             ),
             vm.currentPhrases.getOrAwaitValue()

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.willowtree.vocable.FakeCategoriesUseCase
 import com.willowtree.vocable.MainDispatcherRule
 import com.willowtree.vocable.PhrasesUseCase
+import com.willowtree.vocable.PhrasesUseCaseTest
 import com.willowtree.vocable.getOrAwaitValue
 import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.PhraseDto
@@ -27,11 +28,17 @@ class PresetsViewModelTest {
 
     private val fakePresetsRepository = FakeLegacyCategoriesAndPhrasesRepository()
     private val fakeCategoriesUseCase = FakeCategoriesUseCase()
+    private val fakePhrasesUseCase = PhrasesUseCase(
+        legacyPhrasesRepository = fakePresetsRepository,
+        storedPhrasesRepository = PhrasesUseCaseTest.StubStoredPhrasesRepository(),
+        presetPhrasesRepository = PhrasesUseCaseTest.StubPresetPhrasesRepository(),
+        dateProvider = FakeDateProvider(),
+    )
 
     private fun createViewModel(): PresetsViewModel {
         return PresetsViewModel(
             fakeCategoriesUseCase,
-            PhrasesUseCase(fakePresetsRepository, FakeDateProvider())
+            fakePhrasesUseCase,
         )
     }
 
@@ -156,7 +163,8 @@ class PresetsViewModelTest {
                 CustomPhrase(
                     phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
-                    sortOrder = 0
+                    sortOrder = 0,
+                    lastSpokenDate = 0L,
                 ),
                 null
             ),
@@ -205,12 +213,14 @@ class PresetsViewModelTest {
                 CustomPhrase(
                     phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
-                    sortOrder = 0
+                    sortOrder = 0,
+                    lastSpokenDate = 0L,
                 ),
                 CustomPhrase(
                     phraseId = "1",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Hello")),
-                    sortOrder = 1
+                    sortOrder = 1,
+                    lastSpokenDate = 0L,
                 ),
                 null
             ),
@@ -257,12 +267,14 @@ class PresetsViewModelTest {
                 CustomPhrase(
                     phraseId = "1",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Hello")),
-                    sortOrder = 1
+                    sortOrder = 1,
+                    lastSpokenDate = 0L,
                 ),
                 CustomPhrase(
                     phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
-                    sortOrder = 0
+                    sortOrder = 0,
+                    lastSpokenDate = 0L,
                 )
             ),
             vm.currentPhrases.getOrAwaitValue()

--- a/app/src/test/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.willowtree.vocable.FakeCategoriesUseCase
 import com.willowtree.vocable.MainDispatcherRule
 import com.willowtree.vocable.PhrasesUseCase
+import com.willowtree.vocable.PhrasesUseCaseTest
 import com.willowtree.vocable.presets.FakeLegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.createStoredCategory
 import com.willowtree.vocable.utils.FakeDateProvider
@@ -26,7 +27,12 @@ class EditCategoriesViewModelTest {
 
     private fun createViewModel(): EditCategoriesViewModel {
         return EditCategoriesViewModel(
-            PhrasesUseCase(fakePresetsRepository, FakeDateProvider()),
+            PhrasesUseCase(
+                legacyPhrasesRepository = fakePresetsRepository,
+                storedPhrasesRepository = PhrasesUseCaseTest.StubStoredPhrasesRepository(),
+                presetPhrasesRepository = PhrasesUseCaseTest.StubPresetPhrasesRepository(),
+                dateProvider = FakeDateProvider(),
+            ),
             categoriesUseCase,
             FakeLocalizedResourceUtility()
         )


### PR DESCRIPTION
Doing the smallest possible change to PhrasesUseCase as we start to transition to using the separated preset/stored phrase database tables. This sets up infrastructure to test PhrasesUseCase with backing by an in-memory room database as well.
