### PR TITLE
Allow Updating of Preset Phrases

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -156,8 +156,7 @@ class PhrasesUseCaseTest {
                     phraseId = "1",
                     localizedUtterance = testLocalesWithText,
                     sortOrder = 0,
-                    lastSpokenDate = null,
-                    parentCategoryId = "category"
+                    lastSpokenDate = null
                 )
             ),
             useCase.getPhrasesForCategory("category")

--- a/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -12,6 +12,7 @@ import com.willowtree.vocable.room.RoomStoredPhrasesRepository
 import com.willowtree.vocable.room.VocableDatabase
 import com.willowtree.vocable.utility.FakeDateProvider
 import com.willowtree.vocable.utility.StubLegacyCategoriesAndPhrasesRepository
+import com.willowtree.vocable.utils.UUIDProvider
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.test.runTest
@@ -43,17 +44,21 @@ class PhrasesUseCaseTest {
             legacyPhrasesRepository = legacyRepository,
             storedPhrasesRepository = storedPhrasesRepository,
             presetPhrasesRepository = presetPhrasesRepository,
-            dateProvider = dateProvider
+            dateProvider = dateProvider,
+            uuidProvider = object : UUIDProvider {
+                override fun randomUUIDString(): String = "random"
+            }
         )
     }
 
     @Test
     fun getPhrasesForRecentsCategory_returnsRecentPhrases() = runTest {
         val useCase = createUseCase()
+        val phraseId = "1"
         presetPhrasesRepository.populateDatabase()
         storedPhrasesRepository.addPhrase(
             PhraseDto(
-                phraseId = 1L,
+                phraseId = phraseId,
                 localizedUtterance = testLocalesWithText,
                 parentCategoryId = PresetCategories.GENERAL.id,
                 creationDate = 0L,
@@ -67,7 +72,7 @@ class PhrasesUseCaseTest {
         val recentPhrases = useCase.getPhrasesForCategory(PresetCategories.RECENTS.id)
 
         assertEquals(2, recentPhrases.size)
-        assertEquals("1", recentPhrases[1].phraseId)
+        assertEquals(phraseId, recentPhrases[1].phraseId)
         assertEquals("category_123_0", recentPhrases[0].phraseId)
     }
 
@@ -78,7 +83,7 @@ class PhrasesUseCaseTest {
         for (i in 0..9) {
             storedPhrasesRepository.addPhrase(
                 PhraseDto(
-                    phraseId = i.toLong(),
+                    phraseId = i.toString(),
                     localizedUtterance = testLocalesWithText,
                     parentCategoryId = PresetCategories.GENERAL.id,
                     creationDate = 0L,
@@ -125,7 +130,7 @@ class PhrasesUseCaseTest {
     fun getPhrasesForCategory_getsStoredPhrasesInCategory() = runTest {
         storedPhrasesRepository.addPhrase(
             PhraseDto(
-                phraseId = 1L,
+                phraseId = "1",
                 parentCategoryId = "category",
                 creationDate = 0L,
                 lastSpokenDate = null,
@@ -135,7 +140,7 @@ class PhrasesUseCaseTest {
         )
         storedPhrasesRepository.addPhrase(
             PhraseDto(
-                phraseId = 2L,
+                phraseId = "2",
                 parentCategoryId = "not-category",
                 creationDate = 0L,
                 lastSpokenDate = null,
@@ -152,9 +157,47 @@ class PhrasesUseCaseTest {
                     localizedUtterance = testLocalesWithText,
                     sortOrder = 0,
                     lastSpokenDate = null,
+                    parentCategoryId = "category"
                 )
             ),
             useCase.getPhrasesForCategory("category")
         )
+    }
+
+    @Test
+    fun updatePhrase_updatesCustomPhrase() = runTest {
+        val useCase = createUseCase()
+        val phraseId = "1"
+        val localizedUtterance = LocalesWithText(mapOf("en" to "updated text"))
+        storedPhrasesRepository.addPhrase(
+            PhraseDto(
+                phraseId = phraseId,
+                parentCategoryId = "category",
+                creationDate = 0L,
+                lastSpokenDate = null,
+                localizedUtterance = testLocalesWithText,
+                sortOrder = 0
+            )
+        )
+
+        useCase.updatePhrase(phraseId, localizedUtterance)
+
+        val updatedPhrase = useCase.getPhrasesForCategory("category")
+            .single() as CustomPhrase
+        assertEquals(localizedUtterance, updatedPhrase.localizedUtterance)
+    }
+
+    @Test
+    fun updatePhrase_updatesPresetPhrase() = runTest {
+        val useCase = createUseCase()
+        presetPhrasesRepository.populateDatabase()
+        val phraseId = "category_123_0"
+        val localizedUtterance = LocalesWithText(mapOf("en" to "updated text"))
+
+        useCase.updatePhrase(phraseId, localizedUtterance)
+
+        val newCustomPhrase = useCase.getPhrasesForCategory(PresetCategories.USER_KEYPAD.id)
+            .singleOrNull { it.phraseId == phraseId } as CustomPhrase
+        assertEquals(localizedUtterance, newCustomPhrase.localizedUtterance)
     }
 }

--- a/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -181,9 +181,12 @@ class PhrasesUseCaseTest {
 
         useCase.updatePhrase(phraseId, localizedUtterance)
 
-        val updatedPhrase = useCase.getPhrasesForCategory("category")
-            .single() as CustomPhrase
-        assertEquals(localizedUtterance, updatedPhrase.localizedUtterance)
+        val updatedPhrases = useCase.getPhrasesForCategory("category")
+        assertEquals(updatedPhrases.size, 1)
+        assertEquals(
+            localizedUtterance,
+            (updatedPhrases[0] as CustomPhrase).localizedUtterance
+        )
     }
 
     @Test

--- a/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
@@ -66,7 +66,8 @@ class RoomPresetPhrasesRepositoryTest {
                         PresetPhrase(
                             phraseId = phraseEntryName,
                             sortOrder = index,
-                            lastSpokenDate = null
+                            lastSpokenDate = null,
+                            parentCategoryId = presetCategory.id
                         )
                     )
                 }

--- a/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
@@ -343,7 +343,7 @@ class MigrationTest {
         assertEquals(
             listOf(
                 PhraseDto(
-                    1L,
+                    "1",
                     "custom",
                     0L,
                     0L,
@@ -355,7 +355,7 @@ class MigrationTest {
         assertEquals(
             listOf(
                 PhraseDto(
-                    2L,
+                    "2",
                     "recents",
                     0L,
                     0L,

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/StubLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/StubLegacyCategoriesAndPhrasesRepository.kt
@@ -32,11 +32,6 @@ class StubLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
 
     override suspend fun getRecentPhrases(): List<PhraseDto> = error("Not implemented")
 
-    override suspend fun updatePhraseLastSpoken(phraseId: String, lastSpokenDate: Long)
-        = error("Not implemented")
-
     override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText)
         = error("Not implemented")
-
-    override suspend fun addPhrase(phrase: PhraseDto) = error("Not implemented")
 }

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/StubLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/StubLegacyCategoriesAndPhrasesRepository.kt
@@ -31,7 +31,4 @@ class StubLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
     override suspend fun deleteCategory(categoryId: String) = error("Not implemented")
 
     override suspend fun getRecentPhrases(): List<PhraseDto> = error("Not implemented")
-
-    override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText)
-        = error("Not implemented")
 }

--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -73,7 +73,7 @@ object AppKoinModule {
         single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
         single { LocalizedResourceUtility(androidContext()) } bind ILocalizedResourceUtility::class
         single { CategoriesUseCase(get(), get(), get(), get()) } bind ICategoriesUseCase::class
-        single { PhrasesUseCase(get(), get(), get(), get()) } bind IPhrasesUseCase::class
+        single { PhrasesUseCase(get(), get(), get(), get(), get()) } bind IPhrasesUseCase::class
         single { RandomUUIDProvider() } bind UUIDProvider::class
         single { JavaDateProvider() } bind DateProvider::class
         single { JavaLocaleProvider() } bind LocaleProvider::class

--- a/app/src/main/java/com/willowtree/vocable/PhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/PhrasesUseCase.kt
@@ -39,7 +39,7 @@ class PhrasesUseCase(
     }
 
     override suspend fun addPhrase(localizedUtterance: LocalesWithText, parentCategoryId: String) {
-        legacyPhrasesRepository.addPhrase(PhraseDto(
+        storedPhrasesRepository.addPhrase(PhraseDto(
             phraseId = 0L,
             parentCategoryId = parentCategoryId,
             creationDate = dateProvider.currentTimeMillis(),

--- a/app/src/main/java/com/willowtree/vocable/presets/ILegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/ILegacyCategoriesAndPhrasesRepository.kt
@@ -26,7 +26,5 @@ interface ILegacyCategoriesAndPhrasesRepository {
     suspend fun updateCategoryHidden(categoryId: String, hidden: Boolean)
     suspend fun deleteCategory(categoryId: String)
     suspend fun getRecentPhrases(): List<PhraseDto>
-    suspend fun updatePhraseLastSpoken(phraseId: String, lastSpokenDate: Long)
     suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText)
-    suspend fun addPhrase(phrase: PhraseDto)
 }

--- a/app/src/main/java/com/willowtree/vocable/presets/ILegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/ILegacyCategoriesAndPhrasesRepository.kt
@@ -26,5 +26,4 @@ interface ILegacyCategoriesAndPhrasesRepository {
     suspend fun updateCategoryHidden(categoryId: String, hidden: Boolean)
     suspend fun deleteCategory(categoryId: String)
     suspend fun getRecentPhrases(): List<PhraseDto>
-    suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText)
 }

--- a/app/src/main/java/com/willowtree/vocable/presets/LegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/LegacyCategoriesAndPhrasesRepository.kt
@@ -6,7 +6,6 @@ import com.willowtree.vocable.room.CategoryLocalizedName
 import com.willowtree.vocable.room.CategorySortOrder
 import com.willowtree.vocable.room.PhraseDto
 import com.willowtree.vocable.room.PhraseLocalizedUtterance
-import com.willowtree.vocable.room.PhraseSpokenDate
 import com.willowtree.vocable.room.VocableDatabase
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import kotlinx.coroutines.flow.Flow
@@ -34,10 +33,6 @@ class LegacyCategoriesAndPhrasesRepository(
     override suspend fun getRecentPhrases(): List<PhraseDto> =
         database.phraseDao().getRecentPhrases()
 
-    override suspend fun addPhrase(phrase: PhraseDto) {
-        database.phraseDao().insertPhrase(phrase)
-    }
-
     private suspend fun populatePhrases(phrases: List<PhraseDto>) {
         database.phraseDao().insertPhrases(*phrases.toTypedArray())
     }
@@ -61,10 +56,6 @@ class LegacyCategoriesAndPhrasesRepository(
     override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText) {
         database.phraseDao()
             .updatePhraseLocalizedUtterance(PhraseLocalizedUtterance(phraseId, localizedUtterance))
-    }
-
-    override suspend fun updatePhraseLastSpoken(phraseId: String, lastSpokenDate: Long) {
-        database.phraseDao().updatePhraseSpokenDate(PhraseSpokenDate(phraseId, lastSpokenDate))
     }
 
     override suspend fun updateCategoryName(categoryId: String, localizedName: LocalesWithText) {

--- a/app/src/main/java/com/willowtree/vocable/presets/LegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/LegacyCategoriesAndPhrasesRepository.kt
@@ -5,13 +5,10 @@ import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.room.CategoryLocalizedName
 import com.willowtree.vocable.room.CategorySortOrder
 import com.willowtree.vocable.room.PhraseDto
-import com.willowtree.vocable.room.PhraseLocalizedUtterance
 import com.willowtree.vocable.room.VocableDatabase
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import kotlinx.coroutines.flow.Flow
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
-import java.util.Locale
 
 class LegacyCategoriesAndPhrasesRepository(
     val context: Context,
@@ -53,48 +50,11 @@ class LegacyCategoriesAndPhrasesRepository(
         database.categoryDao().deleteCategory(categoryId)
     }
 
-    override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText) {
-        database.phraseDao()
-            .updatePhraseLocalizedUtterance(PhraseLocalizedUtterance(phraseId, localizedUtterance))
-    }
-
     override suspend fun updateCategoryName(categoryId: String, localizedName: LocalesWithText) {
         database.categoryDao().updateCategory(CategoryLocalizedName(categoryId, localizedName))
     }
 
     override suspend fun updateCategoryHidden(categoryId: String, hidden: Boolean) {
         TODO("Not yet implemented")
-    }
-
-    //Initial DB populate
-    suspend fun populateDatabase() {
-        PresetCategories.values().forEach { presetCategory ->
-            if (presetCategory != PresetCategories.RECENTS && presetCategory != PresetCategories.MY_SAYINGS) {
-                val phrasesIds =
-                    get<Context>().resources.obtainTypedArray(presetCategory.getArrayId())
-                val phraseObjects = mutableListOf<PhraseDto>()
-                for (index in 0 until phrasesIds.length()) {
-                    phraseObjects.add(
-                        PhraseDto(
-                            phraseId = 0L,
-                            parentCategoryId = presetCategory.id,
-                            creationDate = System.currentTimeMillis(),
-                            lastSpokenDate = null,
-                            localizedUtterance = LocalesWithText(
-                                mapOf(
-                                    Pair(
-                                        Locale.getDefault().toString(),
-                                        context.getString(phrasesIds.getResourceId(index, -1))
-                                    )
-                                )
-                            ),
-                            sortOrder = phraseObjects.size,
-                        )
-                    )
-                }
-                phrasesIds.recycle()
-                populatePhrases(phraseObjects)
-            }
-        }
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
@@ -12,6 +12,7 @@ sealed interface Phrase : Parcelable {
     val phraseId: String
     val sortOrder: Int
     val lastSpokenDate: Long?
+    val parentCategoryId: String?
 
     fun text(context: Context): String
 }
@@ -22,6 +23,7 @@ data class CustomPhrase(
     override val sortOrder: Int,
     val localizedUtterance: LocalesWithText?,
     override val lastSpokenDate: Long?,
+    override val parentCategoryId: String?,
 ) : Phrase, Parcelable {
 
     override fun text(context: Context): String {
@@ -34,6 +36,7 @@ data class PresetPhrase(
     override val phraseId: String,
     override val sortOrder: Int,
     override val lastSpokenDate: Long?,
+    override val parentCategoryId: String?,
 ) : Phrase {
 
     override fun text(context: Context): String {
@@ -52,6 +55,7 @@ fun PhraseDto.asPhrase(): Phrase =
         sortOrder = sortOrder,
         localizedUtterance = localizedUtterance,
         lastSpokenDate = lastSpokenDate,
+        parentCategoryId = parentCategoryId,
     )
 
 fun PresetPhraseDto.asPhrase(): PresetPhrase =
@@ -59,4 +63,5 @@ fun PresetPhraseDto.asPhrase(): PresetPhrase =
         phraseId = phraseId,
         sortOrder = sortOrder,
         lastSpokenDate = lastSpokenDate,
+        parentCategoryId = parentCategoryId
     )

--- a/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
@@ -12,7 +12,6 @@ sealed interface Phrase : Parcelable {
     val phraseId: String
     val sortOrder: Int
     val lastSpokenDate: Long?
-    val parentCategoryId: String?
 
     fun text(context: Context): String
 }
@@ -23,7 +22,6 @@ data class CustomPhrase(
     override val sortOrder: Int,
     val localizedUtterance: LocalesWithText?,
     override val lastSpokenDate: Long?,
-    override val parentCategoryId: String?,
 ) : Phrase, Parcelable {
 
     override fun text(context: Context): String {
@@ -36,7 +34,7 @@ data class PresetPhrase(
     override val phraseId: String,
     override val sortOrder: Int,
     override val lastSpokenDate: Long?,
-    override val parentCategoryId: String?,
+    val parentCategoryId: String?,
 ) : Phrase {
 
     override fun text(context: Context): String {
@@ -55,7 +53,6 @@ fun PhraseDto.asPhrase(): Phrase =
         sortOrder = sortOrder,
         localizedUtterance = localizedUtterance,
         lastSpokenDate = lastSpokenDate,
-        parentCategoryId = parentCategoryId,
     )
 
 fun PresetPhraseDto.asPhrase(): PresetPhrase =

--- a/app/src/main/java/com/willowtree/vocable/room/PhraseDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PhraseDao.kt
@@ -28,4 +28,7 @@ interface PhraseDao {
 
     @Query("SELECT * FROM Phrase WHERE parent_category_id == :categoryId")
     suspend fun getPhrasesForCategory(categoryId: String): List<PhraseDto>
+
+    @Query("SELECT * FROM Phrase WHERE phrase_id == :phraseId")
+    suspend fun getPhrase(phraseId: String): PhraseDto?
 }

--- a/app/src/main/java/com/willowtree/vocable/room/PhraseDto.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PhraseDto.kt
@@ -10,7 +10,7 @@ import kotlinx.parcelize.Parcelize
 @Entity(tableName = "Phrase")
 @Parcelize
 data class PhraseDto(
-    @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "phrase_id") val phraseId: Long,
+    @PrimaryKey @ColumnInfo(name = "phrase_id") val phraseId: String,
     @ColumnInfo(name = "parent_category_id") val parentCategoryId: String?,
     @ColumnInfo(name = "creation_date") val creationDate: Long,
     @ColumnInfo(name = "last_spoken_date") val lastSpokenDate: Long?,

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhraseDto.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhraseDto.kt
@@ -14,4 +14,5 @@ data class PresetPhraseDto(
     @ColumnInfo(name = "creation_date") val creationDate: Long,
     @ColumnInfo(name = "last_spoken_date") val lastSpokenDate: Long?,
     @ColumnInfo(name = "sort_order") val sortOrder: Int,
+    @ColumnInfo(name = "hidden") val hidden: Boolean = false
 ) : Parcelable

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesDao.kt
@@ -23,4 +23,10 @@ interface PresetPhrasesDao {
 
     @Query("SELECT * FROM PresetPhrase WHERE parent_category_id = :categoryId")
     suspend fun getPhrasesForCategory(categoryId: String): List<PresetPhraseDto>
+
+    @Query("SELECT * FROM PresetPhrase WHERE phrase_id = :phraseId")
+    suspend fun getPhrase(phraseId: String): PresetPhraseDto?
+
+    @Query("UPDATE PresetPhrase SET hidden = :hidden WHERE phrase_id = :phraseId")
+    suspend fun updatePhraseHidden(phraseId: String, hidden: Boolean)
 }

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesRepository.kt
@@ -1,5 +1,6 @@
 package com.willowtree.vocable.room
 
+import com.willowtree.vocable.presets.Phrase
 import com.willowtree.vocable.presets.PresetPhrase
 
 interface PresetPhrasesRepository {
@@ -8,4 +9,6 @@ interface PresetPhrasesRepository {
     suspend fun updatePhraseLastSpokenTime(phraseId: String)
     suspend fun getRecentPhrases() : List<PresetPhrase>
     suspend fun getPhrasesForCategory(categoryId: String): List<PresetPhrase>
+    suspend fun getPhrase(phraseId: String): Phrase?
+    suspend fun updatePhraseHidden(phraseId: String, hidden: Boolean)
 }

--- a/app/src/main/java/com/willowtree/vocable/room/RoomPresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/RoomPresetPhrasesRepository.kt
@@ -35,11 +35,29 @@ class RoomPresetPhrasesRepository(
     }
 
     override suspend fun getRecentPhrases(): List<PresetPhrase> {
-        return presetPhrasesDao.getRecentPhrases().map { it.asPhrase()}
+        return presetPhrasesDao.getRecentPhrases()
+            .filterHiddenPresets()
+            .map { it.asPhrase()}
     }
 
     override suspend fun getPhrasesForCategory(categoryId: String): List<PresetPhrase> {
-        return presetPhrasesDao.getPhrasesForCategory(categoryId).map { it.asPhrase() }
+        return presetPhrasesDao.getPhrasesForCategory(categoryId)
+            .filterHiddenPresets()
+            .map { it.asPhrase() }
+    }
+
+    override suspend fun getPhrase(phraseId: String): PresetPhrase? {
+        return presetPhrasesDao.getPhrase(phraseId)
+            .takeIf { it?.hidden != true }
+            ?.asPhrase()
+    }
+
+    override suspend fun updatePhraseHidden(phraseId: String, hidden: Boolean) {
+        presetPhrasesDao.updatePhraseHidden(phraseId, hidden)
+    }
+
+    private fun List<PresetPhraseDto>.filterHiddenPresets() : List<PresetPhraseDto> {
+        return filterNot { it.hidden }
     }
 
     private suspend fun ensurePopulated() {

--- a/app/src/main/java/com/willowtree/vocable/room/RoomStoredPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/RoomStoredPhrasesRepository.kt
@@ -3,6 +3,7 @@ package com.willowtree.vocable.room
 import com.willowtree.vocable.presets.Phrase
 import com.willowtree.vocable.presets.asPhrase
 import com.willowtree.vocable.utils.DateProvider
+import com.willowtree.vocable.utils.locale.LocalesWithText
 
 class RoomStoredPhrasesRepository(
     private val database: VocableDatabase,
@@ -27,5 +28,25 @@ class RoomStoredPhrasesRepository(
 
     override suspend fun getPhrasesForCategory(categoryId: String): List<Phrase> {
         return database.phraseDao().getPhrasesForCategory(categoryId).map { it.asPhrase() }
+    }
+
+    override suspend fun getPhrase(phraseId: String): Phrase? {
+        return database.phraseDao().getPhrase(phraseId)?.asPhrase()
+    }
+
+    override suspend fun updatePhrase(phrase: PhraseDto) {
+        database.phraseDao().insertPhrase(phrase)
+    }
+
+    override suspend fun updatePhraseLocalizedUtterance(
+        phraseId: String,
+        localizedUtterance: LocalesWithText
+    ) {
+        database.phraseDao().updatePhraseLocalizedUtterance(
+            PhraseLocalizedUtterance(
+                phraseId = phraseId,
+                localizedUtterance = localizedUtterance
+            )
+        )
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/room/StoredPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/StoredPhrasesRepository.kt
@@ -1,10 +1,17 @@
 package com.willowtree.vocable.room
 
 import com.willowtree.vocable.presets.Phrase
+import com.willowtree.vocable.utils.locale.LocalesWithText
 
 interface StoredPhrasesRepository {
     suspend fun addPhrase(phrase: PhraseDto)
     suspend fun updatePhraseLastSpokenTime(phraseId: String)
     suspend fun getRecentPhrases(): List<Phrase>
     suspend fun getPhrasesForCategory(categoryId: String): List<Phrase>
+    suspend fun getPhrase(phraseId: String): Phrase?
+    suspend fun updatePhrase(phrase: PhraseDto)
+    suspend fun updatePhraseLocalizedUtterance(
+        phraseId: String,
+        localizedUtterance: LocalesWithText,
+    )
 }

--- a/app/src/main/java/com/willowtree/vocable/settings/EditPhrasesKeyboardFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditPhrasesKeyboardFragment.kt
@@ -50,17 +50,14 @@ class EditPhrasesKeyboardFragment : EditKeyboardFragment() {
             if (!isDefaultTextVisible()) {
                 binding.keyboardInput.text.let { text ->
                     if (text.isNotBlank()) {
-                        when (val savingPhrase = phrase) {
+                        val localesWithText = when (val savingPhrase = phrase) {
                             is CustomPhrase -> {
-                                val languageWithText = savingPhrase.localizedUtterance
-                                    ?: LocalesWithText(emptyMap())
-                                viewModel.updatePhrase(savingPhrase.phraseId, languageWithText)
-                                addNewPhrase = false
+                                savingPhrase.localizedUtterance ?: LocalesWithText(emptyMap())
                             }
-                            is PresetPhrase -> {
-                                error("Preset phrases can not currently be edited: $savingPhrase")
-                            }
+                            is PresetPhrase -> LocalesWithText(mapOf("en" to text.toString()))
                         }
+                        viewModel.updatePhrase(phrase.phraseId, localesWithText)
+                        addNewPhrase = false
                     }
                 }
             }

--- a/app/src/test/java/com/willowtree/vocable/FakePhrasesUseCase.kt
+++ b/app/src/test/java/com/willowtree/vocable/FakePhrasesUseCase.kt
@@ -25,7 +25,7 @@ class FakePhrasesUseCase : IPhrasesUseCase {
     var _categoriesToPhrases = mapOf(
         "1" to listOf(
             PhraseDto(
-                phraseId = 1L,
+                phraseId = "1",
                 parentCategoryId = "1",
                 creationDate = 0L,
                 lastSpokenDate = null,

--- a/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
@@ -27,7 +27,7 @@ class FakeLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
     var _categoriesToPhrases = mapOf(
         "1" to listOf(
             PhraseDto(
-                phraseId = 1L,
+                phraseId = "1",
                 parentCategoryId = "1",
                 creationDate = 0L,
                 lastSpokenDate = null,
@@ -39,7 +39,7 @@ class FakeLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
 
     var _recentPhrases = listOf(
         PhraseDto(
-            phraseId = 1L,
+            phraseId = "1",
             parentCategoryId = "1",
             creationDate = 0L,
             lastSpokenDate = null,
@@ -102,7 +102,4 @@ class FakeLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
     }
 
     override suspend fun getRecentPhrases(): List<PhraseDto> = _recentPhrases
-    override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText) {
-        TODO("Not yet implemented")
-    }
 }

--- a/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
@@ -102,15 +102,7 @@ class FakeLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
     }
 
     override suspend fun getRecentPhrases(): List<PhraseDto> = _recentPhrases
-    override suspend fun updatePhraseLastSpoken(phraseId: String, lastSpokenDate: Long) {
-        TODO("Not yet implemented")
-    }
-
     override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText) {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun addPhrase(phrase: PhraseDto) {
         TODO("Not yet implemented")
     }
 }

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -157,7 +157,6 @@ class PresetsViewModelTest {
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0,
                     lastSpokenDate = null,
-                    parentCategoryId = "2",
                 ),
                 null
             ),
@@ -208,14 +207,12 @@ class PresetsViewModelTest {
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0,
                     lastSpokenDate = null,
-                    parentCategoryId = "2",
                 ),
                 CustomPhrase(
                     phraseId = "1",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Hello")),
                     sortOrder = 1,
                     lastSpokenDate = null,
-                    parentCategoryId = "2",
                 ),
                 null
             ),
@@ -266,14 +263,12 @@ class PresetsViewModelTest {
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Hello")),
                     sortOrder = 1,
                     lastSpokenDate = null,
-                    parentCategoryId = PresetCategories.RECENTS.id,
                 ),
                 CustomPhrase(
                     phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0,
                     lastSpokenDate = null,
-                    parentCategoryId = PresetCategories.RECENTS.id,
                 )
             ),
             vm.currentPhrases.getOrAwaitValue()

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -128,7 +128,7 @@ class PresetsViewModelTest {
         fakePhrasesUseCase._categoriesToPhrases = mapOf(
             "1" to listOf(
                 PhraseDto(
-                    phraseId = 1L,
+                    phraseId = "1",
                     parentCategoryId = "1",
                     creationDate = 0L,
                     lastSpokenDate = null,
@@ -138,7 +138,7 @@ class PresetsViewModelTest {
             ),
             "2" to listOf(
                 PhraseDto(
-                    phraseId = 2L,
+                    phraseId = "2",
                     parentCategoryId = "2",
                     creationDate = 0L,
                     lastSpokenDate = null,
@@ -157,6 +157,7 @@ class PresetsViewModelTest {
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0,
                     lastSpokenDate = null,
+                    parentCategoryId = "2",
                 ),
                 null
             ),
@@ -181,7 +182,7 @@ class PresetsViewModelTest {
         fakePhrasesUseCase._categoriesToPhrases = mapOf(
             "2" to listOf(
                 PhraseDto(
-                    phraseId = 1L,
+                    phraseId = "1",
                     parentCategoryId = "2",
                     creationDate = 0L,
                     lastSpokenDate = null,
@@ -189,7 +190,7 @@ class PresetsViewModelTest {
                     sortOrder = 1
                 ),
                 PhraseDto(
-                    phraseId = 2L,
+                    phraseId = "2",
                     parentCategoryId = "2",
                     creationDate = 0L,
                     lastSpokenDate = null,
@@ -207,12 +208,14 @@ class PresetsViewModelTest {
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0,
                     lastSpokenDate = null,
+                    parentCategoryId = "2",
                 ),
                 CustomPhrase(
                     phraseId = "1",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Hello")),
                     sortOrder = 1,
                     lastSpokenDate = null,
+                    parentCategoryId = "2",
                 ),
                 null
             ),
@@ -237,7 +240,7 @@ class PresetsViewModelTest {
         fakePhrasesUseCase._categoriesToPhrases = mapOf(
             PresetCategories.RECENTS.id to listOf(
                 PhraseDto(
-                    phraseId = 1L,
+                    phraseId = "1",
                     parentCategoryId = PresetCategories.RECENTS.id,
                     creationDate = 0L,
                     lastSpokenDate = null,
@@ -245,7 +248,7 @@ class PresetsViewModelTest {
                     sortOrder = 1
                 ),
                 PhraseDto(
-                    phraseId = 2L,
+                    phraseId = "2",
                     parentCategoryId = PresetCategories.RECENTS.id,
                     creationDate = 0L,
                     lastSpokenDate = null,
@@ -263,12 +266,14 @@ class PresetsViewModelTest {
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Hello")),
                     sortOrder = 1,
                     lastSpokenDate = null,
+                    parentCategoryId = PresetCategories.RECENTS.id,
                 ),
                 CustomPhrase(
                     phraseId = "2",
                     localizedUtterance = LocalesWithText(mapOf("en_US" to "Goodbye")),
                     sortOrder = 0,
                     lastSpokenDate = null,
+                    parentCategoryId = PresetCategories.RECENTS.id,
                 )
             ),
             vm.currentPhrases.getOrAwaitValue()


### PR DESCRIPTION
Description: 
Allows preset phrases to be edited. When a preset phrase is edited, it is marked as hidden in the preset phrases table and is "shadowed" (to use Kotlin terminology) by the phrase in the custom phrases table. 

Screenshots: 
[vocable-edit-presets.webm](https://github.com/willowtreeapps/vocable-android/assets/58408581/75044fbd-44f8-4f97-91e7-acb3654896ef)

