### PR TITLE
Chore/452 abstract over saved preset categories 12

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,6 +127,7 @@ dependencies {
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
     androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestImplementation "androidx.arch.core:core-testing:2.2.0"
 
     // Testing Navigation
     androidTestImplementation "androidx.navigation:navigation-testing:2.3.1"

--- a/app/schemas/com.willowtree.vocable.room.VocableDatabase/7.json
+++ b/app/schemas/com.willowtree.vocable.room.VocableDatabase/7.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 7,
-    "identityHash": "f525cce9d37cdc1e795319014f0de6bb",
+    "identityHash": "85eddb23319bc66076dc3049648b8948",
     "entities": [
       {
         "tableName": "Category",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category_id` TEXT NOT NULL, `creation_date` INTEGER NOT NULL, `resource_id` INTEGER, `localized_name` TEXT, `hidden` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`category_id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category_id` TEXT NOT NULL, `creation_date` INTEGER NOT NULL, `localized_name` TEXT NOT NULL, `hidden` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`category_id`))",
         "fields": [
           {
             "fieldPath": "categoryId",
@@ -21,16 +21,10 @@
             "notNull": true
           },
           {
-            "fieldPath": "resourceId",
-            "columnName": "resource_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
             "fieldPath": "localizedName",
             "columnName": "localized_name",
             "affinity": "TEXT",
-            "notNull": false
+            "notNull": true
           },
           {
             "fieldPath": "hidden",
@@ -196,7 +190,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f525cce9d37cdc1e795319014f0de6bb')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '85eddb23319bc66076dc3049648b8948')"
     ]
   }
 }

--- a/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
@@ -116,7 +116,7 @@ class CategoriesUseCaseTest {
         storedCategoriesRepository.upsertCategory(
             Category.StoredCategory(
                 "storedCategory",
-                localizedName = null,
+                localizedName = LocalesWithText(mapOf("en_US" to "storedCategory")),
                 hidden = false,
                 sortOrder = 7 // PresetCategories take up the first 6
             )
@@ -135,7 +135,7 @@ class CategoriesUseCaseTest {
             listOf(
                 Category.StoredCategory(
                     "storedCategory",
-                    localizedName = null,
+                    localizedName = LocalesWithText(mapOf("en_US" to "storedCategory")),
                     hidden = false,
                     sortOrder = 6
                 ),
@@ -143,43 +143,36 @@ class CategoriesUseCaseTest {
                     categoryId = PresetCategories.GENERAL.id,
                     sortOrder = 0,
                     hidden = false,
-                    resourceId = PresetCategories.GENERAL.getNameId()
                 ),
                 Category.PresetCategory(
                     categoryId = PresetCategories.BASIC_NEEDS.id,
                     sortOrder = 1,
                     hidden = false,
-                    resourceId = PresetCategories.BASIC_NEEDS.getNameId()
                 ),
                 Category.PresetCategory(
                     categoryId = PresetCategories.PERSONAL_CARE.id,
                     sortOrder = 2,
                     hidden = false,
-                    resourceId = PresetCategories.PERSONAL_CARE.getNameId()
                 ),
                 Category.PresetCategory(
                     categoryId = PresetCategories.CONVERSATION.id,
                     sortOrder = 3,
                     hidden = false,
-                    resourceId = PresetCategories.CONVERSATION.getNameId()
                 ),
                 Category.PresetCategory(
                     categoryId = PresetCategories.ENVIRONMENT.id,
                     sortOrder = 4,
                     hidden = false,
-                    resourceId = PresetCategories.ENVIRONMENT.getNameId()
                 ),
                 Category.PresetCategory(
                     categoryId = PresetCategories.USER_KEYPAD.id,
                     sortOrder = 5,
                     hidden = false,
-                    resourceId = PresetCategories.USER_KEYPAD.getNameId()
                 ),
                 Category.PresetCategory(
                     categoryId = PresetCategories.RECENTS.id,
                     sortOrder = 7,
                     hidden = false,
-                    resourceId = PresetCategories.RECENTS.getNameId()
                 )
             ),
             useCase.categories().first()
@@ -191,7 +184,7 @@ class CategoriesUseCaseTest {
         storedCategoriesRepository.upsertCategory(
             Category.StoredCategory(
                 "storedCategory",
-                localizedName = null,
+                localizedName = LocalesWithText(mapOf("en_US" to "storedCategory")),
                 hidden = false,
                 sortOrder = 0
             )
@@ -202,7 +195,7 @@ class CategoriesUseCaseTest {
         assertEquals(
             Category.StoredCategory(
                 "storedCategory",
-                localizedName = null,
+                localizedName = LocalesWithText(mapOf("en_US" to "storedCategory")),
                 hidden = false,
                 sortOrder = 0
             ),
@@ -213,7 +206,6 @@ class CategoriesUseCaseTest {
                 PresetCategories.BASIC_NEEDS.id,
                 sortOrder = 1,
                 hidden = false,
-                resourceId = R.string.preset_basic_needs
             ),
             useCase.getCategoryById(PresetCategories.BASIC_NEEDS.id)
         )
@@ -306,7 +298,6 @@ class CategoriesUseCaseTest {
                 PresetCategories.BASIC_NEEDS.id,
                 sortOrder = 1,
                 hidden = true,
-                resourceId = R.string.preset_basic_needs
             ),
             useCase.getCategoryById(PresetCategories.BASIC_NEEDS.id)
         )

--- a/app/src/androidTest/java/com/willowtree/vocable/MainDispatcherRule.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/MainDispatcherRule.kt
@@ -1,0 +1,21 @@
+package com.willowtree.vocable
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetCategoriesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetCategoriesRepositoryTest.kt
@@ -29,7 +29,6 @@ class RoomPresetCategoriesRepositoryTest {
                     it.id,
                     it.initialSortOrder,
                     false,
-                    it.getNameId()
                 )
             },
             repository.getPresetCategories().first()

--- a/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
@@ -322,7 +322,6 @@ class MigrationTest {
                 CategoryDto(
                     "custom",
                     0L,
-                    null,
                     LocalesWithText( mapOf("english" to "custom")),
                     false,
                     7
@@ -330,7 +329,6 @@ class MigrationTest {
                 CategoryDto(
                     "recents",
                     0L,
-                    null,
                     LocalesWithText( mapOf("english" to "recents")),
                     false,
                     8

--- a/app/src/androidTest/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
@@ -1,0 +1,78 @@
+package com.willowtree.vocable.settings
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.willowtree.vocable.CategoriesUseCase
+import com.willowtree.vocable.ConstantUUIDProvider
+import com.willowtree.vocable.FakeLocaleProvider
+import com.willowtree.vocable.MainDispatcherRule
+import com.willowtree.vocable.presets.Category
+import com.willowtree.vocable.presets.PresetCategories
+import com.willowtree.vocable.presets.RoomPresetCategoriesRepository
+import com.willowtree.vocable.room.RoomStoredCategoriesRepository
+import com.willowtree.vocable.room.VocableDatabase
+import com.willowtree.vocable.utils.locale.LocalesWithText
+import com.willowtree.vocable.utils.locale.LocalizedResourceUtility
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AddUpdateCategoryViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val database = Room.inMemoryDatabaseBuilder(
+        ApplicationProvider.getApplicationContext(),
+        VocableDatabase::class.java
+    ).build()
+
+    private val presetCategoriesRepository = RoomPresetCategoriesRepository(
+        database
+    )
+
+    private val storedCategoriesRepository = RoomStoredCategoriesRepository(
+        database
+    )
+
+    private val categoriesUseCase = CategoriesUseCase(
+        ConstantUUIDProvider(),
+        FakeLocaleProvider(),
+        storedCategoriesRepository,
+        presetCategoriesRepository
+    )
+
+    private fun createViewModel(): AddUpdateCategoryViewModel {
+        return AddUpdateCategoryViewModel(
+            categoriesUseCase,
+            LocalizedResourceUtility(ApplicationProvider.getApplicationContext()),
+            FakeLocaleProvider()
+        )
+    }
+
+    @Test
+    fun preset_category_name_updated() = runTest {
+        val vm = createViewModel()
+
+        vm.updateCategory(PresetCategories.GENERAL.id, "General 2")
+
+        assertEquals(
+            Category.StoredCategory(
+                categoryId = PresetCategories.GENERAL.id,
+                localizedName = LocalesWithText(mapOf("en_US" to "General 2")),
+                hidden = false,
+                sortOrder = 0
+            ),
+            categoriesUseCase.getCategoryById(PresetCategories.GENERAL.id)
+        )
+    }
+
+}

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/StubLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/StubLegacyCategoriesAndPhrasesRepository.kt
@@ -31,4 +31,7 @@ class StubLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
     override suspend fun deleteCategory(categoryId: String) = error("Not implemented")
 
     override suspend fun getRecentPhrases(): List<PhraseDto> = error("Not implemented")
+    override suspend fun deletePhrases(phrases: List<PhraseDto>) {
+        TODO("Not yet implemented")
+    }
 }

--- a/app/src/main/java/com/willowtree/vocable/presets/Category.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/Category.kt
@@ -1,62 +1,71 @@
 package com.willowtree.vocable.presets
 
+import android.content.Context
 import android.os.Parcelable
+import com.willowtree.vocable.R
 import com.willowtree.vocable.room.CategoryDto
 import com.willowtree.vocable.utils.locale.LocalesWithText
+import com.willowtree.vocable.utils.locale.text
 import kotlinx.parcelize.Parcelize
 
 sealed class Category : Parcelable {
     abstract val categoryId: String
     abstract val sortOrder: Int
     abstract val hidden: Boolean
-    abstract val localizedName: LocalesWithText?
-    abstract val resourceId: Int?
 
     abstract fun withSortOrder(sortOrder: Int): Category
     abstract fun withHidden(hidden: Boolean): Category
+    abstract fun text(context: Context): String
 
     @Parcelize
     data class StoredCategory(
         override val categoryId: String,
-        override val localizedName: LocalesWithText?,
+        val localizedName: LocalesWithText,
         override var hidden: Boolean,
         override var sortOrder: Int
     ) : Category() {
-        override val resourceId: Int? = null
         override fun withSortOrder(sortOrder: Int): Category = copy(sortOrder = sortOrder)
         override fun withHidden(hidden: Boolean): Category = copy(hidden = hidden)
+        override fun text(context: Context): String {
+            return localizedName.localizedText.text()
+        }
     }
 
     @Parcelize
     data class Recents(
-        override val resourceId: Int?,
-        override val localizedName: LocalesWithText?,
         override val hidden: Boolean,
         override val sortOrder: Int
     ) : Category() {
         override val categoryId: String = PresetCategories.RECENTS.id
         override fun withSortOrder(sortOrder: Int): Category = copy(sortOrder = sortOrder)
         override fun withHidden(hidden: Boolean): Category = copy(hidden = hidden)
+        override fun text(context: Context): String {
+            return context.getString(R.string.preset_recents)
+        }
     }
 
     @Parcelize
     data class PresetCategory(
         override val categoryId: String,
         override val sortOrder: Int,
-        override val hidden: Boolean,
-        override val resourceId: Int
+        override val hidden: Boolean
     ) : Category() {
-        override val localizedName: LocalesWithText? = null
         override fun withSortOrder(sortOrder: Int): Category = copy(sortOrder = sortOrder)
         override fun withHidden(hidden: Boolean): Category = copy(hidden = hidden)
+        override fun text(context: Context): String {
+            val categoryStringRes = context.resources.getIdentifier(
+                /* name = */ categoryId,
+                /* defType = */ "string",
+                /* defPackage = */ context.packageName
+            )
+            return context.resources.getString(categoryStringRes)
+        }
     }
 }
 
 fun CategoryDto.asCategory(): Category {
     return if (categoryId == PresetCategories.RECENTS.id) {
         Category.Recents(
-            resourceId = resourceId,
-            localizedName = localizedName,
             hidden = hidden,
             sortOrder = sortOrder
         )

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetCategories.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetCategories.kt
@@ -3,11 +3,11 @@ package com.willowtree.vocable.presets
 import com.willowtree.vocable.R
 
 enum class PresetCategories(val id: String, val initialSortOrder: Int) {
-    GENERAL("preset_general_category_id", 0),
-    BASIC_NEEDS("preset_basic_needs_category_id", 1),
-    PERSONAL_CARE("preset_personal_care_category_id", 2),
-    CONVERSATION("preset_conversation_category_id", 3),
-    ENVIRONMENT("preset_environment_category_id", 4 ),
+    GENERAL("preset_general", 0),
+    BASIC_NEEDS("preset_basic_needs", 1),
+    PERSONAL_CARE("preset_personal_care", 2),
+    CONVERSATION("preset_conversation", 3),
+    ENVIRONMENT("preset_environment", 4 ),
     USER_KEYPAD("preset_user_keypad", 5),
     RECENTS("preset_recents", 6),
     @Deprecated("This is being filtered out from the UI already. Remove this.")
@@ -23,19 +23,6 @@ enum class PresetCategories(val id: String, val initialSortOrder: Int) {
             USER_KEYPAD -> R.array.category_123
             RECENTS -> -1
             MY_SAYINGS -> -1 // Not localized with same convention
-        }
-    }
-
-    fun getNameId(): Int {
-        return when (this) {
-            GENERAL -> R.string.preset_general
-            BASIC_NEEDS -> R.string.preset_basic_needs
-            CONVERSATION -> R.string.preset_conversation
-            ENVIRONMENT -> R.string.preset_environment
-            PERSONAL_CARE -> R.string.preset_personal_care
-            USER_KEYPAD -> R.string.preset_user_keypad
-            MY_SAYINGS -> R.string.preset_user_favorites
-            RECENTS -> R.string.preset_recents
         }
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/presets/RoomPresetCategoriesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/RoomPresetCategoriesRepository.kt
@@ -26,10 +26,7 @@ class RoomPresetCategoriesRepository(
                     Category.PresetCategory(
                         it.categoryId,
                         it.sortOrder,
-                        it.hidden,
-                        PresetCategories.values()
-                            .first { presetCategory -> presetCategory.id == it.categoryId }
-                            .getNameId()
+                        it.hidden
                     )
                 }
         }.onStart { ensurePopulated() }
@@ -68,10 +65,7 @@ class RoomPresetCategoriesRepository(
             Category.PresetCategory(
                 it.categoryId,
                 it.sortOrder,
-                it.hidden,
-                PresetCategories.values()
-                    .first { presetCategory -> presetCategory.id == it.categoryId }
-                    .getNameId()
+                it.hidden
             )
         }
     }

--- a/app/src/main/java/com/willowtree/vocable/room/CategoryDto.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/CategoryDto.kt
@@ -12,8 +12,7 @@ import kotlinx.parcelize.Parcelize
 data class CategoryDto(
     @PrimaryKey @ColumnInfo(name = "category_id") val categoryId: String,
     @ColumnInfo(name = "creation_date") val creationDate: Long,
-    @ColumnInfo(name = "resource_id") val resourceId: Int?,
-    @ColumnInfo(name = "localized_name") var localizedName: LocalesWithText?,
+    @ColumnInfo(name = "localized_name") var localizedName: LocalesWithText,
     var hidden: Boolean,
     @ColumnInfo(name = "sort_order") var sortOrder: Int
 ) : Parcelable

--- a/app/src/main/java/com/willowtree/vocable/room/RoomStoredCategoriesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/RoomStoredCategoriesRepository.kt
@@ -16,7 +16,6 @@ class RoomStoredCategoriesRepository(
             CategoryDto(
                 category.categoryId,
                 0L,
-                category.resourceId,
                 category.localizedName,
                 category.hidden,
                 category.sortOrder

--- a/app/src/main/java/com/willowtree/vocable/room/Version7Migration.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/Version7Migration.kt
@@ -1,0 +1,10 @@
+package com.willowtree.vocable.room
+
+import androidx.room.DeleteColumn
+import androidx.room.migration.AutoMigrationSpec
+
+@DeleteColumn(
+    tableName = "Category",
+    columnName = "resource_id"
+)
+class Version7Migration : AutoMigrationSpec

--- a/app/src/main/java/com/willowtree/vocable/room/VocableDatabase.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/VocableDatabase.kt
@@ -16,7 +16,7 @@ import androidx.room.TypeConverters
     ],
     version = 7,
     // TODO: PK - May be able to consolidate 6 and 7 since we never released 6
-    autoMigrations = [AutoMigration(from = 6, to = 7)]
+    autoMigrations = [AutoMigration(from = 6, to = 7, spec = Version7Migration::class)]
 )
 @TypeConverters(Converters::class)
 abstract class VocableDatabase : RoomDatabase() {

--- a/app/src/main/java/com/willowtree/vocable/room/VocableDatabaseMigrations.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/VocableDatabaseMigrations.kt
@@ -3,6 +3,7 @@ package com.willowtree.vocable.room
 import android.annotation.SuppressLint
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.willowtree.vocable.R
 import com.willowtree.vocable.presets.PresetCategories
 import com.willowtree.vocable.utils.VocableSharedPreferences
 import java.util.*
@@ -101,7 +102,7 @@ object VocableDatabaseMigrations {
 
             }
 
-            database.execSQL("INSERT INTO Category_New (category_id, creation_date, is_user_generated, resource_id, localized_name, hidden, sort_order) VALUES ('${PresetCategories.MY_SAYINGS.id}', ${System.currentTimeMillis()}, 0, ${PresetCategories.MY_SAYINGS.getNameId()}, null, 0, ${PresetCategories.MY_SAYINGS.initialSortOrder})")
+            database.execSQL("INSERT INTO Category_New (category_id, creation_date, is_user_generated, resource_id, localized_name, hidden, sort_order) VALUES ('${PresetCategories.MY_SAYINGS.id}', ${System.currentTimeMillis()}, 0, ${R.string.preset_user_favorites}, null, 0, ${PresetCategories.MY_SAYINGS.initialSortOrder})")
 
             var sortOrder = 0
             myLocalizedSayings.forEach { localizedSaying ->

--- a/app/src/main/java/com/willowtree/vocable/utils/locale/LocalizedResourceUtility.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/locale/LocalizedResourceUtility.kt
@@ -11,13 +11,7 @@ class LocalizedResourceUtility(
 ) : KoinComponent, ILocalizedResourceUtility {
 
     override fun getTextFromCategory(category: Category?): String {
-        return category?.localizedName?.localizedText?.text() ?: category?.resourceId?.let {
-            if (it != 0) {
-                context.resources.getString(it)
-            } else {
-                ""
-            }
-        } ?: ""
+        return category?.text(context) ?: ""
     }
 
     fun getTextFromPhrase(phrase: Phrase?): String {

--- a/app/src/test/java/com/willowtree/vocable/FakeCategoriesUseCase.kt
+++ b/app/src/test/java/com/willowtree/vocable/FakeCategoriesUseCase.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 
+@Deprecated("This fake is too complex, tests using it should migrate to integration tests with" +
+        "the actual data sources.")
 class FakeCategoriesUseCase : ICategoriesUseCase {
 
     val _categories = MutableStateFlow<List<Category>>(

--- a/app/src/test/java/com/willowtree/vocable/FakeCategoriesUseCase.kt
+++ b/app/src/test/java/com/willowtree/vocable/FakeCategoriesUseCase.kt
@@ -9,11 +9,11 @@ import kotlinx.coroutines.flow.update
 
 class FakeCategoriesUseCase : ICategoriesUseCase {
 
-    val _categories = MutableStateFlow(
+    val _categories = MutableStateFlow<List<Category>>(
         listOf(
             Category.StoredCategory(
                 "categoryId",
-                null,
+                LocalesWithText(mapOf("en_US" to "storedCategory")),
                 false,
                 0
             )
@@ -31,7 +31,17 @@ class FakeCategoriesUseCase : ICategoriesUseCase {
         _categories.update { categories ->
             categories.map {
                 if (it.categoryId == categoryId) {
-                    it.copy(localizedName = localizedName)
+                    when (it) {
+                        is Category.StoredCategory -> it.copy(localizedName = localizedName)
+                        is Category.PresetCategory -> Category.StoredCategory(
+                            it.categoryId,
+                            localizedName,
+                            it.hidden,
+                            it.sortOrder
+                        )
+
+                        is Category.Recents -> it
+                    }
                 } else {
                     it
                 }
@@ -56,7 +66,11 @@ class FakeCategoriesUseCase : ICategoriesUseCase {
                 val sortOrderUpdate =
                     categorySortOrders.firstOrNull { it.categoryId == categoryDto.categoryId }
                 if (sortOrderUpdate != null) {
-                    categoryDto.copy(sortOrder = sortOrderUpdate.sortOrder)
+                    when(categoryDto) {
+                        is Category.StoredCategory -> categoryDto.copy(sortOrder = sortOrderUpdate.sortOrder)
+                        is Category.PresetCategory -> categoryDto.copy(sortOrder = sortOrderUpdate.sortOrder)
+                        is Category.Recents -> categoryDto.copy(sortOrder = sortOrderUpdate.sortOrder)
+                    }
                 } else {
                     categoryDto
                 }
@@ -72,7 +86,11 @@ class FakeCategoriesUseCase : ICategoriesUseCase {
         _categories.update { categories ->
             categories.map {
                 if (it.categoryId == categoryId) {
-                    it.copy(hidden = hidden)
+                    when(it) {
+                        is Category.StoredCategory -> it.copy(hidden = hidden)
+                        is Category.PresetCategory -> it.copy(hidden = hidden)
+                        is Category.Recents -> it.copy(hidden = hidden)
+                    }
                 } else {
                     it
                 }

--- a/app/src/test/java/com/willowtree/vocable/FakePhrasesUseCase.kt
+++ b/app/src/test/java/com/willowtree/vocable/FakePhrasesUseCase.kt
@@ -14,7 +14,6 @@ class FakePhrasesUseCase : IPhrasesUseCase {
             CategoryDto(
                 categoryId = "1",
                 creationDate = 0L,
-                resourceId = null,
                 localizedName = LocalesWithText(mapOf("en_US" to "category")),
                 hidden = false,
                 sortOrder = 0

--- a/app/src/test/java/com/willowtree/vocable/presets/CategoryExt.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/CategoryExt.kt
@@ -4,7 +4,7 @@ import com.willowtree.vocable.utils.locale.LocalesWithText
 
 fun createStoredCategory(
     categoryId: String,
-    localizedName: LocalesWithText? = LocalesWithText(mapOf("en_US" to "category")),
+    localizedName: LocalesWithText = LocalesWithText(mapOf("en_US" to "category")),
     hidden: Boolean = false,
     sortOrder: Int = 0
 ): Category.StoredCategory = Category.StoredCategory(

--- a/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
@@ -16,7 +16,6 @@ class FakeLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
             CategoryDto(
                 categoryId = "1",
                 creationDate = 0L,
-                resourceId = null,
                 localizedName = LocalesWithText( mapOf("en_US" to "category")),
                 hidden = false,
                 sortOrder = 0

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -116,7 +116,6 @@ class PresetsViewModelTest {
                 CategoryDto(
                     categoryId = "1",
                     creationDate = 0L,
-                    resourceId = null,
                     localizedName = LocalesWithText(mapOf("en_US" to "category")),
                     hidden = false,
                     sortOrder = 0
@@ -124,7 +123,6 @@ class PresetsViewModelTest {
                 CategoryDto(
                     categoryId = "2",
                     creationDate = 0L,
-                    resourceId = null,
                     localizedName = LocalesWithText(mapOf("en_US" to "second category")),
                     hidden = false,
                     sortOrder = 0
@@ -177,7 +175,6 @@ class PresetsViewModelTest {
                 CategoryDto(
                     categoryId = "2",
                     creationDate = 0L,
-                    resourceId = null,
                     localizedName = LocalesWithText(mapOf("en_US" to "category")),
                     hidden = false,
                     sortOrder = 0
@@ -233,7 +230,6 @@ class PresetsViewModelTest {
                 CategoryDto(
                     categoryId = PresetCategories.RECENTS.id,
                     creationDate = 0L,
-                    resourceId = null,
                     localizedName = LocalesWithText(mapOf("en_US" to "category")),
                     hidden = false,
                     sortOrder = 0

--- a/app/src/test/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
@@ -38,13 +38,13 @@ class AddUpdateCategoryViewModelTest {
             listOf(
                 Category.StoredCategory(
                     categoryId = "1",
-                    localizedName = null,
+                    localizedName = LocalesWithText(mapOf("en_US" to "storedCategory")),
                     hidden = false,
                     sortOrder = 0
                 ),
                 Category.StoredCategory(
                     categoryId = "2",
-                    localizedName = null,
+                    localizedName = LocalesWithText(mapOf("en_US" to "storedCategory2")),
                     hidden = true,
                     sortOrder = 1
                 )
@@ -59,13 +59,13 @@ class AddUpdateCategoryViewModelTest {
             listOf(
                 Category.StoredCategory(
                     categoryId = "1",
-                    localizedName = null,
+                    localizedName = LocalesWithText(mapOf("en_US" to "storedCategory")),
                     hidden = false,
                     sortOrder = 0
                 ),
                 Category.StoredCategory(
                     categoryId = "2",
-                    localizedName = null,
+                    localizedName = LocalesWithText(mapOf("en_US" to "storedCategory2")),
                     hidden = true,
                     sortOrder = 2
                 ),
@@ -81,7 +81,7 @@ class AddUpdateCategoryViewModelTest {
     }
 
     @Test
-    fun `category name updated`() = runTest {
+    fun `stored category name updated`() = runTest {
         categoriesUseCase._categories.update {
             listOf(
                 Category.StoredCategory(

--- a/app/src/test/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
@@ -14,6 +14,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 
+@Deprecated("We should migrate this over to androidTest, as the Fake CategoriesUseCase is" +
+        "getting too complex.")
 class AddUpdateCategoryViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/com/willowtree/vocable/utils/FakeLocalizedResourceUtility.kt
+++ b/app/src/test/java/com/willowtree/vocable/utils/FakeLocalizedResourceUtility.kt
@@ -4,6 +4,11 @@ import com.willowtree.vocable.presets.Category
 
 class FakeLocalizedResourceUtility : ILocalizedResourceUtility {
     override fun getTextFromCategory(category: Category?): String {
-        return category?.localizedName?.localesTextMap?.entries?.first()?.value ?: ""
+        return when(category) {
+            is Category.PresetCategory -> category.categoryId
+            is Category.Recents -> "Recents"
+            is Category.StoredCategory -> category.localizedName.localesTextMap.entries.first().value
+            null -> ""
+        }
     }
 }


### PR DESCRIPTION
Resource IDs are not stable. We were also needing to differentiate the type of category to get the category's name, this way that's abstracted away. 

We still need another field to differentiate from the UI's idea of "hidden" and the idea of a preset category being permanently hidden. Until then, modifying the name of a preset category will result in it still appearing in settings.