### PR TITLE
"Delete" preset category when renaming

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
@@ -241,7 +241,7 @@ class CategoriesUseCaseTest {
     }
 
     @Test
-    fun update_category_name_hides_preset_category_and_creates_stored_category_with_new_name() =
+    fun update_category_name_deletes_preset_category_and_creates_stored_category_with_new_name() =
         runTest {
             val useCase = createUseCase()
 
@@ -258,6 +258,11 @@ class CategoriesUseCaseTest {
                     localizedName = LocalesWithText(mapOf("en_US" to "newPresetCategory1")),
                 ),
                 useCase.getCategoryById(PresetCategories.BASIC_NEEDS.id)
+            )
+            assertEquals(
+                1,
+                useCase.categories().first()
+                    .filter { it.categoryId == PresetCategories.BASIC_NEEDS.id }.size
             )
         }
 

--- a/app/src/main/java/com/willowtree/vocable/CategoriesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/CategoriesUseCase.kt
@@ -49,7 +49,7 @@ class CategoriesUseCase(
         } else {
             val presetCategory = presetCategoriesRepository.getCategoryById(categoryId)
             if (presetCategory != null) {
-                presetCategoriesRepository.updateCategoryHidden(categoryId, true)
+                presetCategoriesRepository.deleteCategory(categoryId)
                 storedCategoriesRepository.upsertCategory(
                     Category.StoredCategory(
                         presetCategory.categoryId,

--- a/app/src/main/java/com/willowtree/vocable/room/models/PresetCategory.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/models/PresetCategory.kt
@@ -1,7 +1,0 @@
-package com.willowtree.vocable.room.models
-
-data class PresetCategory(
-    val id: String,
-    val localizedName: Map<String, String>,
-    val hidden: Boolean
-)


### PR DESCRIPTION
We already had the notion of deleting apparently. This is separate from hiding, and is permanent for a preset category. This is transparent to the user in the renaming case.