### PR TITLE
Allow Deletion of Preset Phrases

### DIFF
--- a/app/schemas/com.willowtree.vocable.room.VocableDatabase/7.json
+++ b/app/schemas/com.willowtree.vocable.room.VocableDatabase/7.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 7,
-    "identityHash": "85eddb23319bc66076dc3049648b8948",
+    "identityHash": "594aeaa35a106dec45ceb3c0c04fb345",
     "entities": [
       {
         "tableName": "Category",
@@ -138,7 +138,7 @@
       },
       {
         "tableName": "PresetPhrase",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`phrase_id` TEXT NOT NULL, `parent_category_id` TEXT NOT NULL, `creation_date` INTEGER NOT NULL, `last_spoken_date` INTEGER, `sort_order` INTEGER NOT NULL, `hidden` INTEGER NOT NULL, PRIMARY KEY(`phrase_id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`phrase_id` TEXT NOT NULL, `parent_category_id` TEXT NOT NULL, `creation_date` INTEGER NOT NULL, `last_spoken_date` INTEGER, `sort_order` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`phrase_id`))",
         "fields": [
           {
             "fieldPath": "phraseId",
@@ -171,8 +171,8 @@
             "notNull": true
           },
           {
-            "fieldPath": "hidden",
-            "columnName": "hidden",
+            "fieldPath": "deleted",
+            "columnName": "deleted",
             "affinity": "INTEGER",
             "notNull": true
           }
@@ -190,7 +190,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '85eddb23319bc66076dc3049648b8948')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '594aeaa35a106dec45ceb3c0c04fb345')"
     ]
   }
 }

--- a/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -202,4 +202,39 @@ class PhrasesUseCaseTest {
             .singleOrNull { it.phraseId == phraseId } as CustomPhrase
         assertEquals(localizedUtterance, newCustomPhrase.localizedUtterance)
     }
+
+    @Test
+    fun deletePhrase_deletesFromStoredRepository() = runTest {
+        val useCase = createUseCase()
+        val customPhraseId = "1"
+        storedPhrasesRepository.addPhrase(
+            PhraseDto(
+                phraseId = customPhraseId,
+                localizedUtterance = testLocalesWithText,
+                parentCategoryId = PresetCategories.GENERAL.id,
+                creationDate = 0L,
+                lastSpokenDate = 100L,
+                sortOrder = 0
+            )
+        )
+
+        useCase.deletePhrase(customPhraseId)
+
+        val storedPhrase = useCase.getPhrasesForCategory(PresetCategories.GENERAL.id)
+            .firstOrNull { it.phraseId == customPhraseId }
+        assertEquals(null, storedPhrase)
+    }
+
+    @Test
+    fun deletePhrase_deletesFromPresetRepository() = runTest {
+        val useCase = createUseCase()
+        val presetPhraseId = "category_123_0"
+        presetPhrasesRepository.populateDatabase()
+
+        useCase.deletePhrase(presetPhraseId)
+
+        val presetPhrase = useCase.getPhrasesForCategory(PresetCategories.USER_KEYPAD.id)
+            .firstOrNull { it.phraseId == presetPhraseId }
+        assertEquals(null, presetPhrase)
+    }
 }

--- a/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
@@ -67,7 +67,8 @@ class RoomPresetPhrasesRepositoryTest {
                             phraseId = phraseEntryName,
                             sortOrder = index,
                             lastSpokenDate = null,
-                            parentCategoryId = presetCategory.id
+                            parentCategoryId = presetCategory.id,
+                            deleted = false,
                         )
                     )
                 }

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/StubLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/StubLegacyCategoriesAndPhrasesRepository.kt
@@ -17,8 +17,6 @@ class StubLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
 
     override suspend fun getAllCategories() = error("Not implemented")
 
-    override suspend fun deletePhrase(phraseId: String) = error("Not implemented")
-
     override suspend fun updateCategorySortOrders(categorySortOrders: List<CategorySortOrder>) =
         error("Not implemented")
 

--- a/app/src/main/java/com/willowtree/vocable/presets/ILegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/ILegacyCategoriesAndPhrasesRepository.kt
@@ -20,7 +20,6 @@ interface ILegacyCategoriesAndPhrasesRepository {
      * Return all categories, sorted by [CategoryDto.sortOrder]
      */
     suspend fun getAllCategories(): List<CategoryDto>
-    suspend fun deletePhrase(phraseId: String)
     suspend fun updateCategorySortOrders(categorySortOrders: List<CategorySortOrder>)
     suspend fun updateCategoryName(categoryId: String, localizedName: LocalesWithText)
     suspend fun updateCategoryHidden(categoryId: String, hidden: Boolean)

--- a/app/src/main/java/com/willowtree/vocable/presets/LegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/LegacyCategoriesAndPhrasesRepository.kt
@@ -30,14 +30,6 @@ class LegacyCategoriesAndPhrasesRepository(
     override suspend fun getRecentPhrases(): List<PhraseDto> =
         database.phraseDao().getRecentPhrases()
 
-    private suspend fun populatePhrases(phrases: List<PhraseDto>) {
-        database.phraseDao().insertPhrases(*phrases.toTypedArray())
-    }
-
-    override suspend fun deletePhrase(phraseId: String) {
-        database.phraseDao().deletePhrase(phraseId)
-    }
-
     override suspend fun updateCategorySortOrders(categorySortOrders: List<CategorySortOrder>) {
         database.categoryDao().updateCategorySortOrders(categorySortOrders)
     }

--- a/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/Phrase.kt
@@ -34,6 +34,7 @@ data class PresetPhrase(
     override val phraseId: String,
     override val sortOrder: Int,
     override val lastSpokenDate: Long?,
+    val deleted: Boolean,
     val parentCategoryId: String?,
 ) : Phrase {
 
@@ -49,7 +50,7 @@ data class PresetPhrase(
 
 fun PhraseDto.asPhrase(): Phrase =
     CustomPhrase(
-        phraseId = phraseId.toString(),
+        phraseId = phraseId,
         sortOrder = sortOrder,
         localizedUtterance = localizedUtterance,
         lastSpokenDate = lastSpokenDate,
@@ -60,5 +61,6 @@ fun PresetPhraseDto.asPhrase(): PresetPhrase =
         phraseId = phraseId,
         sortOrder = sortOrder,
         lastSpokenDate = lastSpokenDate,
-        parentCategoryId = parentCategoryId
+        parentCategoryId = parentCategoryId,
+        deleted = deleted,
     )

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhraseDto.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhraseDto.kt
@@ -14,5 +14,5 @@ data class PresetPhraseDto(
     @ColumnInfo(name = "creation_date") val creationDate: Long,
     @ColumnInfo(name = "last_spoken_date") val lastSpokenDate: Long?,
     @ColumnInfo(name = "sort_order") val sortOrder: Int,
-    @ColumnInfo(name = "hidden") val hidden: Boolean = false
+    @ColumnInfo(name = "deleted") val deleted: Boolean = false,
 ) : Parcelable

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesDao.kt
@@ -27,6 +27,6 @@ interface PresetPhrasesDao {
     @Query("SELECT * FROM PresetPhrase WHERE phrase_id = :phraseId")
     suspend fun getPhrase(phraseId: String): PresetPhraseDto?
 
-    @Query("UPDATE PresetPhrase SET hidden = :hidden WHERE phrase_id = :phraseId")
-    suspend fun updatePhraseHidden(phraseId: String, hidden: Boolean)
+    @Query("UPDATE PresetPhrase SET deleted = :deleted WHERE phrase_id = :phraseId")
+    suspend fun deletePhrase(phraseId: String, deleted: Boolean)
 }

--- a/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/PresetPhrasesRepository.kt
@@ -1,6 +1,5 @@
 package com.willowtree.vocable.room
 
-import com.willowtree.vocable.presets.Phrase
 import com.willowtree.vocable.presets.PresetPhrase
 
 interface PresetPhrasesRepository {
@@ -9,6 +8,6 @@ interface PresetPhrasesRepository {
     suspend fun updatePhraseLastSpokenTime(phraseId: String)
     suspend fun getRecentPhrases() : List<PresetPhrase>
     suspend fun getPhrasesForCategory(categoryId: String): List<PresetPhrase>
-    suspend fun getPhrase(phraseId: String): Phrase?
-    suspend fun updatePhraseHidden(phraseId: String, hidden: Boolean)
+    suspend fun getPhrase(phraseId: String): PresetPhrase?
+    suspend fun deletePhrase(phraseId: String)
 }

--- a/app/src/main/java/com/willowtree/vocable/room/RoomPresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/RoomPresetPhrasesRepository.kt
@@ -36,28 +36,26 @@ class RoomPresetPhrasesRepository(
 
     override suspend fun getRecentPhrases(): List<PresetPhrase> {
         return presetPhrasesDao.getRecentPhrases()
-            .filterHiddenPresets()
+            .filterDeletedPresets()
             .map { it.asPhrase()}
     }
 
     override suspend fun getPhrasesForCategory(categoryId: String): List<PresetPhrase> {
         return presetPhrasesDao.getPhrasesForCategory(categoryId)
-            .filterHiddenPresets()
+            .filterDeletedPresets()
             .map { it.asPhrase() }
     }
 
     override suspend fun getPhrase(phraseId: String): PresetPhrase? {
-        return presetPhrasesDao.getPhrase(phraseId)
-            .takeIf { it?.hidden != true }
-            ?.asPhrase()
+        return presetPhrasesDao.getPhrase(phraseId)?.asPhrase()
     }
 
-    override suspend fun updatePhraseHidden(phraseId: String, hidden: Boolean) {
-        presetPhrasesDao.updatePhraseHidden(phraseId, hidden)
+    override suspend fun deletePhrase(phraseId: String) {
+        presetPhrasesDao.deletePhrase(phraseId, deleted = true)
     }
 
-    private fun List<PresetPhraseDto>.filterHiddenPresets() : List<PresetPhraseDto> {
-        return filterNot { it.hidden }
+    private fun List<PresetPhraseDto>.filterDeletedPresets() : List<PresetPhraseDto> {
+        return filterNot { it.deleted }
     }
 
     private suspend fun ensurePopulated() {

--- a/app/src/main/java/com/willowtree/vocable/room/RoomStoredPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/RoomStoredPhrasesRepository.kt
@@ -49,4 +49,8 @@ class RoomStoredPhrasesRepository(
             )
         )
     }
+
+    override suspend fun deletePhrase(phraseId: String) {
+        database.phraseDao().deletePhrase(phraseId)
+    }
 }

--- a/app/src/main/java/com/willowtree/vocable/room/StoredPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/StoredPhrasesRepository.kt
@@ -14,4 +14,5 @@ interface StoredPhrasesRepository {
         phraseId: String,
         localizedUtterance: LocalesWithText,
     )
+    suspend fun deletePhrase(phraseId: String)
 }

--- a/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/FakeLegacyCategoriesAndPhrasesRepository.kt
@@ -59,10 +59,6 @@ class FakeLegacyCategoriesAndPhrasesRepository : ILegacyCategoriesAndPhrasesRepo
         return _allCategories.value.sortedBy { it.sortOrder }
     }
 
-    override suspend fun deletePhrase(phraseId: String) {
-        TODO("Not yet implemented")
-    }
-
     override suspend fun updateCategorySortOrders(categorySortOrders: List<CategorySortOrder>) {
         _allCategories.update { allCategories ->
             allCategories.map { categoryDto ->


### PR DESCRIPTION
Allows Preset phrases to be deleted from the app. Custom phrases were already deletable, so the UI is the same, but now preset phrases can be deleted too.

[delete_presets.webm](https://github.com/willowtreeapps/vocable-android/assets/58408581/b2b25aee-a438-41b7-9465-3aa6839437a8)

Closes #505 
