### PR TITLE
Handle sorting in CategoriesUseCase

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
@@ -109,17 +109,17 @@ class CategoriesUseCaseTest {
     fun category_stored() = runTest {
         val useCase = createUseCase()
 
-        useCase.addCategory("My Category", 0)
+        useCase.addCategory("My Category")
 
         assertEquals(
             listOf(
+                *presetCategoriesRepository.getPresetCategories().first().toTypedArray(),
                 Category.StoredCategory(
                     categoryId = "1",
                     localizedName = LocalesWithText(mapOf("en_US" to "My Category")),
                     hidden = false,
-                    sortOrder = 0
+                    sortOrder = 7
                 ),
-                *presetCategoriesRepository.getPresetCategories().first().toTypedArray()
             ),
             useCase.categories().first()
         )
@@ -128,7 +128,7 @@ class CategoriesUseCaseTest {
                 categoryId = "1",
                 localizedName = LocalesWithText(mapOf("en_US" to "My Category")),
                 hidden = false,
-                sortOrder = 0
+                sortOrder = 7
             ),
             useCase.getCategoryById("1")
         )
@@ -379,6 +379,24 @@ class CategoriesUseCaseTest {
         assertEquals(
             emptyList<PresetPhrase>(),
             presetPhrasesRepository.getPhrasesForCategory(PresetCategories.BASIC_NEEDS.id)
+        )
+    }
+
+    @Test
+    fun category_added_before_hidden() = runTest {
+        val useCase = createUseCase()
+        useCase.updateCategoryHidden(PresetCategories.BASIC_NEEDS.id, true)
+
+        useCase.addCategory("New category")
+
+        assertEquals(
+            Category.StoredCategory(
+                categoryId = "1",
+                localizedName = LocalesWithText(mapOf("en_US" to "New category")),
+                hidden = false,
+                sortOrder = 7
+            ),
+            useCase.categories().first()[6]
         )
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/ICategoriesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/ICategoriesUseCase.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 interface ICategoriesUseCase {
     fun categories(): Flow<List<Category>>
     suspend fun updateCategoryName(categoryId: String, localizedName: LocalesWithText)
-    suspend fun addCategory(categoryName: String, sortOrder: Int)
+    suspend fun addCategory(categoryName: String)
     suspend fun updateCategorySortOrders(categorySortOrders: List<CategorySortOrder>)
     suspend fun getCategoryById(categoryId: String): Category
     suspend fun updateCategoryHidden(categoryId: String, hidden: Boolean)

--- a/app/src/main/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.ICategoriesUseCase
 import com.willowtree.vocable.presets.Category
-import com.willowtree.vocable.room.CategorySortOrder
 import com.willowtree.vocable.utils.ILocalizedResourceUtility
 import com.willowtree.vocable.utils.locale.LocaleProvider
 import com.willowtree.vocable.utils.locale.LocalesWithText
@@ -57,30 +56,7 @@ class AddUpdateCategoryViewModel(
 
     fun addCategory(categoryName: String) {
         viewModelScope.launch {
-            val allCategories = categoriesUseCase.categories().first()
-            // Don't allow duplicate category names
-            if (categoryNameExists(categoryName)) {
-                liveShowDuplicateCategoryMessage.postValue(true)
-                return@launch
-            }
-
-            // Get the index of the first hidden category to find the sort order of new category
-            var firstHiddenIndex = allCategories.indexOfFirst { it.hidden }
-            if (firstHiddenIndex == -1) {
-                firstHiddenIndex = allCategories.size
-            }
-
-            // Increase the sort order of all hidden categories since the new one will be sorted
-            // before them
-            val listToUpdate = allCategories.filter { it.hidden }.toMutableList()
-            listToUpdate.forEachIndexed { index, category ->
-                listToUpdate[index] = category.withSortOrder(category.sortOrder + 1)
-            }
-
-            with(categoriesUseCase) {
-                addCategory(categoryName, firstHiddenIndex)
-                updateCategorySortOrders(listToUpdate.map { CategorySortOrder(it.categoryId, it.sortOrder) })
-            }
+            categoriesUseCase.addCategory(categoryName)
 
             liveShowCategoryUpdateMessage.postValue(true)
             delay(CATEGORY_MESSAGE_DELAY)

--- a/app/src/test/java/com/willowtree/vocable/FakeCategoriesUseCase.kt
+++ b/app/src/test/java/com/willowtree/vocable/FakeCategoriesUseCase.kt
@@ -51,13 +51,13 @@ class FakeCategoriesUseCase : ICategoriesUseCase {
         }
     }
 
-    override suspend fun addCategory(categoryName: String, sortOrder: Int) {
+    override suspend fun addCategory(categoryName: String) {
         _categories.update {
             it + Category.StoredCategory(
                 "",
                 LocalesWithText(mapOf("en_US" to categoryName)),
                 false,
-                sortOrder
+                0
             )
         }
     }

--- a/app/src/test/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
@@ -35,54 +35,6 @@ class AddUpdateCategoryViewModelTest {
     }
 
     @Test
-    fun `new category added before hidden categories`() {
-        categoriesUseCase._categories.update {
-            listOf(
-                Category.StoredCategory(
-                    categoryId = "1",
-                    localizedName = LocalesWithText(mapOf("en_US" to "storedCategory")),
-                    hidden = false,
-                    sortOrder = 0
-                ),
-                Category.StoredCategory(
-                    categoryId = "2",
-                    localizedName = LocalesWithText(mapOf("en_US" to "storedCategory2")),
-                    hidden = true,
-                    sortOrder = 1
-                )
-            )
-        }
-
-        val vm = createViewModel()
-
-        vm.addCategory("New Category")
-
-        assertEquals(
-            listOf(
-                Category.StoredCategory(
-                    categoryId = "1",
-                    localizedName = LocalesWithText(mapOf("en_US" to "storedCategory")),
-                    hidden = false,
-                    sortOrder = 0
-                ),
-                Category.StoredCategory(
-                    categoryId = "2",
-                    localizedName = LocalesWithText(mapOf("en_US" to "storedCategory2")),
-                    hidden = true,
-                    sortOrder = 2
-                ),
-                Category.StoredCategory(
-                    categoryId = "",
-                    localizedName = LocalesWithText(mapOf("en_US" to "New Category")),
-                    hidden = false,
-                    sortOrder = 1
-                )
-            ),
-            categoriesUseCase._categories.value
-        )
-    }
-
-    @Test
     fun `stored category name updated`() = runTest {
         categoriesUseCase._categories.update {
             listOf(


### PR DESCRIPTION
We don't need to actually update sort order when adding a category, if we're cool with it always being at the end of the list. Additionally, we can check for hidden and do that sorting at the same layer, further simplifying the logic.