### PR TITLE
Remove test orchestrator

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,9 +45,6 @@ android {
             buildConfigField("boolean", "USE_HEAD_TRACKING", useHeadTracking)
         }
     }
-    testOptions {
-        execution 'ANDROIDX_TEST_ORCHESTRATOR'
-    }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
@@ -112,8 +109,6 @@ dependencies {
 
     // Moshi
     implementation 'com.squareup.moshi:moshi-kotlin:1.12.0'
-
-    androidTestUtil 'androidx.test:orchestrator:1.4.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"


### PR DESCRIPTION
Orchestrator slows down tests significantly. The primary gain is to remove shared state between test cases, but none of our tests are having issues with that, and when they do, we should solve it with in-memory fakes instead of using orchestrator.