### PR TITLE
Add notion of category pages

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
@@ -9,9 +9,13 @@ import com.willowtree.vocable.IPhrasesUseCase
 import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.presets.Phrase
 import com.willowtree.vocable.room.CategorySortOrder
+import com.willowtree.vocable.settings.editcategories.EditCategoriesPage
 import com.willowtree.vocable.utils.ILocalizedResourceUtility
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlin.math.ceil
+import kotlin.math.min
 
 class EditCategoriesViewModel(
     private val phrasesUseCase: IPhrasesUseCase,
@@ -24,6 +28,17 @@ class EditCategoriesViewModel(
 
     private val liveAddRemoveCategoryList = MutableLiveData<List<Category>>()
     val addRemoveCategoryList: LiveData<List<Category>> = liveAddRemoveCategoryList
+
+    val categoryPages = categoriesUseCase.categories().map { categories ->
+        val pageSize = 8
+        val pageCount = ceil(categories.size / pageSize.toFloat()).toInt()
+
+        (0 until pageCount).map {
+            val start = it * pageSize
+            val end = min((it + 1) * pageSize, categories.size)
+            EditCategoriesPage(categories.subList(start, end))
+        }
+    }
 
     private val liveLastViewedIndex = MutableLiveData<Int>()
     val lastViewedIndex: LiveData<Int> = liveLastViewedIndex

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
@@ -14,8 +14,6 @@ import com.willowtree.vocable.utils.ILocalizedResourceUtility
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlin.math.ceil
-import kotlin.math.min
 
 class EditCategoriesViewModel(
     private val phrasesUseCase: IPhrasesUseCase,
@@ -31,13 +29,7 @@ class EditCategoriesViewModel(
 
     val categoryPages = categoriesUseCase.categories().map { categories ->
         val pageSize = 8
-        val pageCount = ceil(categories.size / pageSize.toFloat()).toInt()
-
-        (0 until pageCount).map {
-            val start = it * pageSize
-            val end = min((it + 1) * pageSize, categories.size)
-            EditCategoriesPage(categories.subList(start, end))
-        }
+        categories.chunked(pageSize).map { EditCategoriesPage(it) }
     }
 
     private val liveLastViewedIndex = MutableLiveData<Int>()
@@ -113,9 +105,11 @@ class EditCategoriesViewModel(
                         categoryId -> {
                             it.withSortOrder(it.sortOrder - 1)
                         }
+
                         previousCat.categoryId -> {
                             it.withSortOrder(it.sortOrder + 1)
                         }
+
                         else -> {
                             it
                         }
@@ -144,9 +138,11 @@ class EditCategoriesViewModel(
                         categoryId -> {
                             it.withSortOrder(it.sortOrder + 1)
                         }
+
                         nextCat.categoryId -> {
                             it.withSortOrder(it.sortOrder - 1)
                         }
+
                         else -> {
                             it
                         }

--- a/app/src/main/java/com/willowtree/vocable/settings/editcategories/EditCategoriesPage.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/editcategories/EditCategoriesPage.kt
@@ -1,0 +1,7 @@
+package com.willowtree.vocable.settings.editcategories
+
+import com.willowtree.vocable.presets.Category
+
+data class EditCategoriesPage(
+    val categories: List<Category>
+)

--- a/app/src/test/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
@@ -4,10 +4,12 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.willowtree.vocable.FakeCategoriesUseCase
 import com.willowtree.vocable.FakePhrasesUseCase
 import com.willowtree.vocable.MainDispatcherRule
-import com.willowtree.vocable.presets.FakeLegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.createStoredCategory
+import com.willowtree.vocable.settings.editcategories.EditCategoriesPage
 import com.willowtree.vocable.utils.FakeLocalizedResourceUtility
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -20,7 +22,6 @@ class EditCategoriesViewModelTest {
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    private val fakePresetsRepository = FakeLegacyCategoriesAndPhrasesRepository()
     private val categoriesUseCase = FakeCategoriesUseCase()
     private val phrasesUseCase = FakePhrasesUseCase()
 
@@ -146,6 +147,48 @@ class EditCategoriesViewModelTest {
                 )
             ),
             categoriesUseCase._categories.value
+        )
+    }
+
+    @Test
+    fun `category pages are populated`() = runTest {
+        categoriesUseCase._categories.update {
+            listOf(
+                createStoredCategory(categoryId = "1"),
+                createStoredCategory(categoryId = "2"),
+                createStoredCategory(categoryId = "3"),
+                createStoredCategory(categoryId = "4"),
+                createStoredCategory(categoryId = "5"),
+                createStoredCategory(categoryId = "6"),
+                createStoredCategory(categoryId = "7"),
+                createStoredCategory(categoryId = "8"),
+                createStoredCategory(categoryId = "9"),
+            )
+        }
+        val vm = createViewModel()
+        vm.refreshCategories()
+
+        assertEquals(
+            listOf(
+                EditCategoriesPage(
+                    listOf(
+                        createStoredCategory(categoryId = "1"),
+                        createStoredCategory(categoryId = "2"),
+                        createStoredCategory(categoryId = "3"),
+                        createStoredCategory(categoryId = "4"),
+                        createStoredCategory(categoryId = "5"),
+                        createStoredCategory(categoryId = "6"),
+                        createStoredCategory(categoryId = "7"),
+                        createStoredCategory(categoryId = "8"),
+                    )
+                ),
+                EditCategoriesPage(
+                    listOf(
+                        createStoredCategory(categoryId = "9"),
+                    )
+                )
+            ),
+            vm.categoryPages.first()
         )
     }
 


### PR DESCRIPTION
The idea is that this data can be observed by the page fragments, so that the pager adapter's content never has to actually change unless the page count changes. This should help us mitigate the display issues that are caused by the adapter rebinding any time the category list changes.