### PR TITLE
Use in-memory database for UI tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
         //30 was the last versionCode used on Play Store before implementing CI with github actions
         versionCode Integer.valueOf(System.getenv("VERSION_CODE") ?: 1) + 30
         versionName System.getenv("VERSION_NAME") ?: "pre-release" + "(" + versionCode + ")"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "com.willowtree.vocable.utility.VocableTestRunner"
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments = ["room.schemaLocation": "$projectDir/schemas".toString()]

--- a/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
@@ -13,16 +13,21 @@ import com.willowtree.vocable.room.RoomStoredCategoriesRepository
 import com.willowtree.vocable.room.RoomStoredPhrasesRepository
 import com.willowtree.vocable.room.VocableDatabase
 import com.willowtree.vocable.utility.FakeDateProvider
+import com.willowtree.vocable.utility.VocableKoinTestRule
 import com.willowtree.vocable.utility.StubLegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class CategoriesUseCaseTest {
+
+    @get:Rule
+    val vocableKoinTestRule = VocableKoinTestRule()
 
     private val database = Room.inMemoryDatabaseBuilder(
         ApplicationProvider.getApplicationContext(),

--- a/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -11,17 +11,22 @@ import com.willowtree.vocable.room.RoomPresetPhrasesRepository
 import com.willowtree.vocable.room.RoomStoredPhrasesRepository
 import com.willowtree.vocable.room.VocableDatabase
 import com.willowtree.vocable.utility.FakeDateProvider
+import com.willowtree.vocable.utility.VocableKoinTestRule
 import com.willowtree.vocable.utility.StubLegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.utils.UUIDProvider
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 
 @RunWith(AndroidJUnit4::class)
 class PhrasesUseCaseTest {
+
+    @get:Rule
+    val vocableKoinTestRule = VocableKoinTestRule()
 
     private val database = Room.inMemoryDatabaseBuilder(
         ApplicationProvider.getApplicationContext(),

--- a/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
@@ -7,13 +7,19 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.willowtree.vocable.room.RoomPresetPhrasesRepository
 import com.willowtree.vocable.room.VocableDatabase
 import com.willowtree.vocable.utility.FakeDateProvider
+import com.willowtree.vocable.utility.VocableKoinTestRule
 import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class RoomPresetPhrasesRepositoryTest {
+
+    @get:Rule
+    val vocableKoinTestRule = VocableKoinTestRule()
+
     private fun createRepository(): RoomPresetPhrasesRepository {
         return RoomPresetPhrasesRepository(
             presetPhrasesDao = Room.inMemoryDatabaseBuilder(

--- a/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/room/MigrationTest.kt
@@ -14,11 +14,13 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.willowtree.vocable.presets.PresetCategories
+import com.willowtree.vocable.utility.VocableKoinTestRule
 import com.willowtree.vocable.utils.VocableSharedPreferences
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
@@ -26,6 +28,9 @@ import java.util.*
 
 @RunWith(AndroidJUnit4::class)
 class MigrationTest {
+
+    @get:Rule
+    val vocableKoinTestRule = VocableKoinTestRule()
 
     companion object {
         private const val TEST_DB = "migration-test"

--- a/app/src/androidTest/java/com/willowtree/vocable/tests/BaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/tests/BaseTest.kt
@@ -1,6 +1,5 @@
 package com.willowtree.vocable.tests
 
-import android.Manifest
 import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.matcher.ViewMatchers
@@ -10,6 +9,7 @@ import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
+import com.willowtree.vocable.utility.VocableKoinTestRule
 import com.willowtree.vocable.R
 import com.willowtree.vocable.screens.MainScreen
 import com.willowtree.vocable.splash.SplashActivity
@@ -32,6 +32,9 @@ open class BaseTest {
     private val name = TestName()
 
     @get:Rule
+    val vocableKoinTestRule = VocableKoinTestRule()
+
+    @get:Rule
     val activityRule = ActivityScenarioRule(SplashActivity::class.java)
 
     @get:Rule
@@ -48,7 +51,7 @@ open class BaseTest {
         // Since the build machine gets wiped after every run we can check the file storage
         // of the emulator to determine if this is a first time launch
         // and dismiss the full screen immersive popup on android if it is
-        firstLaunch = getInstrumentation().targetContext.filesDir.listFiles().isEmpty()
+        firstLaunch = getInstrumentation().targetContext.filesDir.listFiles()?.isEmpty() ?: true
         if (firstLaunch) {
             takeScreenshot("InitialSetup")
         }

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/InMemoryDatabase.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/InMemoryDatabase.kt
@@ -1,0 +1,19 @@
+package com.willowtree.vocable.utility
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.willowtree.vocable.room.VocableDatabase
+import com.willowtree.vocable.room.addVocableMigrations
+import org.koin.dsl.module
+
+fun VocableDatabase.Companion.getInMemoryVocableDatabase() = Room
+    .inMemoryDatabaseBuilder(
+        ApplicationProvider.getApplicationContext(),
+        VocableDatabase::class.java
+    )
+    .addVocableMigrations()
+    .build()
+
+val inMemoryDatabaseModule = module {
+    single { VocableDatabase.getInMemoryVocableDatabase() }
+}

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/TestApplication.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/TestApplication.kt
@@ -1,0 +1,5 @@
+package com.willowtree.vocable.utility
+
+import android.app.Application
+
+class TestApplication: Application()

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/VocableKoinTestRule.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/VocableKoinTestRule.kt
@@ -1,0 +1,32 @@
+package com.willowtree.vocable.utility
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.willowtree.vocable.utils.VocableSharedPreferences
+import com.willowtree.vocable.vocableKoinModule
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.module.Module
+
+class VocableKoinTestRule(
+    private vararg val testModules: Module
+): TestWatcher() {
+    override fun starting(description: Description?) {
+        startKoin {
+            androidContext(InstrumentationRegistry.getInstrumentation().targetContext.applicationContext)
+            modules(
+                vocableKoinModule +
+                inMemoryDatabaseModule +
+                testModules.toList()
+            )
+        }.koin.apply {
+            get<VocableSharedPreferences>().clearAll()
+        }
+    }
+
+    override fun finished(description: Description?) {
+        stopKoin()
+    }
+}

--- a/app/src/androidTest/java/com/willowtree/vocable/utility/VocableTestRunner.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/utility/VocableTestRunner.kt
@@ -1,0 +1,15 @@
+package com.willowtree.vocable.utility
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+
+class VocableTestRunner: AndroidJUnitRunner() {
+    override fun newApplication(
+        cl: ClassLoader?,
+        className: String?,
+        context: Context?
+    ): Application {
+        return super.newApplication(cl, TestApplication::class.java.name, context)
+    }
+}

--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -8,7 +8,6 @@ import com.willowtree.vocable.presets.LegacyCategoriesAndPhrasesRepository
 import com.willowtree.vocable.presets.PresetCategoriesRepository
 import com.willowtree.vocable.presets.PresetsViewModel
 import com.willowtree.vocable.presets.RoomPresetCategoriesRepository
-import com.willowtree.vocable.room.PresetPhrasesDao
 import com.willowtree.vocable.room.PresetPhrasesRepository
 import com.willowtree.vocable.room.RoomPresetPhrasesRepository
 import com.willowtree.vocable.room.RoomStoredCategoriesRepository
@@ -44,48 +43,51 @@ import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-object AppKoinModule {
 
-    fun getModule() = module {
+val vocableKoinModule = module {
 
-        scope<MainActivity> {
-            scoped {
-                FaceTrackingManager(get(), get())
-            }
-            scoped<PermissionsRationaleDialogShower> {
-                ActivityPermissionsRationaleDialogShower(get())
-            }
-            scoped<PermissionRequester> {
-                ActivityPermissionRegisterForLaunch(get())
-            }
-            scoped<PermissionsChecker> {
-                ActivityPermissionsChecker(get())
-            }
-            scoped<IFaceTrackingPermissions> {
-                FaceTrackingPermissions(get(), androidContext().packageName, get(), get(), get())
-            }
-            viewModel { FaceTrackingViewModel(get()) }
-            viewModel { SelectionModeViewModel(get()) }
+    scope<MainActivity> {
+        scoped {
+            FaceTrackingManager(get(), get())
         }
-
-        single { VocableSharedPreferences() } bind IVocableSharedPreferences::class
-        single { LegacyCategoriesAndPhrasesRepository(get(), get()) } bind ILegacyCategoriesAndPhrasesRepository::class
-        single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
-        single { LocalizedResourceUtility(androidContext()) } bind ILocalizedResourceUtility::class
-        single { CategoriesUseCase(get(), get(), get(), get(), get()) } bind ICategoriesUseCase::class
-        single { PhrasesUseCase(get(), get(), get(), get(), get()) } bind IPhrasesUseCase::class
-        single { RandomUUIDProvider() } bind UUIDProvider::class
-        single { JavaDateProvider() } bind DateProvider::class
-        single { JavaLocaleProvider() } bind LocaleProvider::class
-        single { RoomStoredCategoriesRepository(get()) } bind StoredCategoriesRepository::class
-        single { RoomPresetCategoriesRepository(get()) } bind PresetCategoriesRepository::class
-        single { RoomStoredPhrasesRepository(get(), get()) } bind StoredPhrasesRepository::class
-        single { RoomPresetPhrasesRepository(get(), get()) } bind PresetPhrasesRepository::class
-        single { VocableDatabase.getVocableDatabase(get()) }
-        single { VocableDatabase.getVocableDatabase(get()).presetPhrasesDao() } bind PresetPhrasesDao::class
-        viewModel { PresetsViewModel(get(), get()) }
-        viewModel { EditCategoriesViewModel(get(), get(), get()) }
-        viewModel { AddUpdateCategoryViewModel(get(), get(), get()) }
-        viewModel { EditCategoryMenuViewModel(get()) }
+        scoped<PermissionsRationaleDialogShower> {
+            ActivityPermissionsRationaleDialogShower(get())
+        }
+        scoped<PermissionRequester> {
+            ActivityPermissionRegisterForLaunch(get())
+        }
+        scoped<PermissionsChecker> {
+            ActivityPermissionsChecker(get())
+        }
+        scoped<IFaceTrackingPermissions> {
+            FaceTrackingPermissions(get(), androidContext().packageName, get(), get(), get())
+        }
+        viewModel { FaceTrackingViewModel(get()) }
+        viewModel { SelectionModeViewModel(get()) }
     }
+
+    single { VocableSharedPreferences() } bind IVocableSharedPreferences::class
+    single {
+        LegacyCategoriesAndPhrasesRepository(
+            get(),
+            get()
+        )
+    } bind ILegacyCategoriesAndPhrasesRepository::class
+    single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
+    single { LocalizedResourceUtility(androidContext()) } bind ILocalizedResourceUtility::class
+    single { CategoriesUseCase(get(), get(), get(), get(), get()) } bind ICategoriesUseCase::class
+    single { PhrasesUseCase(get(), get(), get(), get(), get()) } bind IPhrasesUseCase::class
+    single { RandomUUIDProvider() } bind UUIDProvider::class
+    single { JavaDateProvider() } bind DateProvider::class
+    single { JavaLocaleProvider() } bind LocaleProvider::class
+    single { RoomStoredCategoriesRepository(get()) } bind StoredCategoriesRepository::class
+    single { RoomPresetCategoriesRepository(get()) } bind PresetCategoriesRepository::class
+    single { RoomStoredPhrasesRepository(get(), get()) } bind StoredPhrasesRepository::class
+    single { RoomPresetPhrasesRepository(get(), get()) } bind PresetPhrasesRepository::class
+    single { VocableDatabase.createVocableDatabase(get()) }
+    single { get<VocableDatabase>().presetPhrasesDao() }
+    viewModel { PresetsViewModel(get(), get()) }
+    viewModel { EditCategoriesViewModel(get(), get(), get()) }
+    viewModel { AddUpdateCategoryViewModel(get(), get(), get()) }
+    viewModel { EditCategoryMenuViewModel(get()) }
 }

--- a/app/src/main/java/com/willowtree/vocable/VocableApp.kt
+++ b/app/src/main/java/com/willowtree/vocable/VocableApp.kt
@@ -31,7 +31,7 @@ class VocableApp : Application() {
         startKoin {
             androidContext(this@VocableApp)
 
-            modules(listOf(AppKoinModule.getModule()))
+            modules(vocableKoinModule)
         }
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/room/VocableDatabase.kt
+++ b/app/src/main/java/com/willowtree/vocable/room/VocableDatabase.kt
@@ -22,24 +22,12 @@ import androidx.room.TypeConverters
 abstract class VocableDatabase : RoomDatabase() {
 
     companion object {
-        private var vocableDatabase: VocableDatabase? = null
         private const val DATABASE_NAME = "VocableDatabase"
 
-        fun getVocableDatabase(context: Context): VocableDatabase {
-            if (vocableDatabase == null) {
-                vocableDatabase =
-                    Room.databaseBuilder(context, VocableDatabase::class.java, DATABASE_NAME)
-                        .addMigrations(
-                            VocableDatabaseMigrations.MIGRATION_1_2,
-                            VocableDatabaseMigrations.MIGRATION_2_3,
-                            VocableDatabaseMigrations.MIGRATION_3_4,
-                            VocableDatabaseMigrations.MIGRATION_4_5,
-                            VocableDatabaseMigrations.MIGRATION_5_6
-                        )
-                        .build()
-            }
-            return vocableDatabase as VocableDatabase
-        }
+        fun createVocableDatabase(context: Context): VocableDatabase =
+            Room.databaseBuilder(context, VocableDatabase::class.java, DATABASE_NAME)
+                .addVocableMigrations()
+                .build()
     }
 
     abstract fun categoryDao(): CategoryDao
@@ -51,3 +39,11 @@ abstract class VocableDatabase : RoomDatabase() {
     abstract fun presetCategoryDao(): PresetCategoryDao
 }
 
+fun RoomDatabase.Builder<VocableDatabase>.addVocableMigrations() =
+    addMigrations(
+        VocableDatabaseMigrations.MIGRATION_1_2,
+        VocableDatabaseMigrations.MIGRATION_2_3,
+        VocableDatabaseMigrations.MIGRATION_3_4,
+        VocableDatabaseMigrations.MIGRATION_4_5,
+        VocableDatabaseMigrations.MIGRATION_5_6
+    )

--- a/app/src/main/java/com/willowtree/vocable/utils/VocableSharedPreferences.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/VocableSharedPreferences.kt
@@ -1,5 +1,6 @@
 package com.willowtree.vocable.utils
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
@@ -25,7 +26,7 @@ class VocableSharedPreferences :
         const val KEY_FIRST_TIME = "KEY_FIRST_TIME_OPENING"
     }
 
-    private val encryptedPrefs: EncryptedSharedPreferences by lazy {
+    private val encryptedPrefs: SharedPreferences by lazy {
         val context = get<Context>()
         EncryptedSharedPreferences.create(
             PREFERENCES_NAME,
@@ -33,7 +34,7 @@ class VocableSharedPreferences :
             context,
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        ) as EncryptedSharedPreferences
+        )
     }
 
     override fun registerOnSharedPreferenceChangeListener(vararg listeners: SharedPreferences.OnSharedPreferenceChangeListener) {
@@ -84,4 +85,9 @@ class VocableSharedPreferences :
 
     override fun getFirstTime(): Boolean =
         encryptedPrefs.getBoolean(KEY_FIRST_TIME, true)
+
+    @SuppressLint("ApplySharedPref")
+    fun clearAll() {
+        encryptedPrefs.edit().clear().commit()
+    }
 }


### PR DESCRIPTION
Description: 
* Use in-memory database for UI tests
* Set up koin startup and teardown for tests (via a test rule)
* Clear shared preferences at the beginning of every test so that populating database happens correctly

Screenshots: 
n/a

- [X] Acceptance Criteria satisfied
- [X] Regression Testing
