### PR TITLE
Issue 416: Refactor pager code of edit categories screen

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsFragment.kt
@@ -16,7 +16,7 @@ import com.willowtree.vocable.*
 import com.willowtree.vocable.customviews.PointerListener
 import com.willowtree.vocable.databinding.FragmentPresetsBinding
 import com.willowtree.vocable.utils.SpokenText
-import com.willowtree.vocable.utils.VocableFragmentStateAdapter
+import com.willowtree.vocable.utils.LegacyFragmentStateAdapter
 import com.willowtree.vocable.utils.VocableTextToSpeech
 import org.koin.androidx.viewmodel.ViewModelOwner
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -324,7 +324,7 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
     }
 
     inner class CategoriesPagerAdapter(fm: FragmentManager) :
-        VocableFragmentStateAdapter<Category>(fm, viewLifecycleOwner.lifecycle) {
+        LegacyFragmentStateAdapter<Category>(fm, viewLifecycleOwner.lifecycle) {
 
         override fun getMaxItemsPerPage(): Int = maxCategories
 
@@ -343,7 +343,7 @@ class PresetsFragment : BaseFragment<FragmentPresetsBinding>() {
     }
 
     inner class PhrasesPagerAdapter(fm: FragmentManager) :
-        VocableFragmentStateAdapter<Phrase?>(fm, viewLifecycleOwner.lifecycle) {
+        LegacyFragmentStateAdapter<Phrase?>(fm, viewLifecycleOwner.lifecycle) {
 
         override fun setItems(items: List<Phrase?>) {
             super.setItems(items)

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesListFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesListFragment.kt
@@ -8,7 +8,6 @@ import androidx.navigation.fragment.findNavController
 import com.willowtree.vocable.BaseFragment
 import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
-import com.willowtree.vocable.customviews.NoSayTextButton
 import com.willowtree.vocable.databinding.CategoryEditButtonBinding
 import com.willowtree.vocable.databinding.FragmentEditCategoriesListBinding
 import com.willowtree.vocable.presets.Category
@@ -102,21 +101,23 @@ class EditCategoriesListFragment : BaseFragment<FragmentEditCategoriesListBindin
     }
 
     private fun subscribeToViewModel() {
-        editCategoriesViewModel.orderCategoryList.observe(viewLifecycleOwner) { list ->
+        editCategoriesViewModel.categoryList.observe(viewLifecycleOwner) { list ->
             list?.let { overallList ->
                 val hiddenCategories = overallList.filter { it.hidden }
                 if (endPosition > overallList.size) {
                     endPosition = overallList.size - 1
                 }
-                overallList.subList(startPosition, endPosition)
-                    .forEachIndexed { index, category ->
-                        bindCategoryEditButton(
-                            editButtonList[index],
-                            category,
-                            startPosition + index,
-                            overallList.size - hiddenCategories.size
-                        )
-                    }
+                if (startPosition <= endPosition) {
+                    overallList.subList(startPosition, endPosition)
+                        .forEachIndexed { index, category ->
+                            bindCategoryEditButton(
+                                editButtonList[index],
+                                category,
+                                startPosition + index,
+                                overallList.size - hiddenCategories.size
+                            )
+                        }
+                }
             }
         }
     }
@@ -128,7 +129,7 @@ class EditCategoriesListFragment : BaseFragment<FragmentEditCategoriesListBindin
         size: Int
     ) {
         with(editButtonBinding) {
-            (individualEditCategoryButton as NoSayTextButton).text = localizedResourceUtility.getTextFromCategory(category)
+            individualEditCategoryButton.text = localizedResourceUtility.getTextFromCategory(category)
 
             moveCategoryUpButton.isEnabled = !category.hidden && overallIndex > 0
             moveCategoryDownButton.isEnabled =

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
@@ -3,6 +3,7 @@ package com.willowtree.vocable.settings
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.ICategoriesUseCase
 import com.willowtree.vocable.presets.Category
@@ -16,11 +17,11 @@ class EditCategoriesViewModel(
     private val categoriesUseCase: ICategoriesUseCase
 ) : ViewModel() {
 
-    private val liveOrderCategoryList = MutableLiveData<List<Category>>()
-    val orderCategoryList: LiveData<List<Category>> = liveOrderCategoryList
-
-    private val liveAddRemoveCategoryList = MutableLiveData<List<Category>>()
-    val addRemoveCategoryList: LiveData<List<Category>> = liveAddRemoveCategoryList
+    val categoryList: LiveData<List<Category>> = categoriesUseCase.categories()
+        .map { categories ->
+            categories.sortedBy { it.sortOrder }
+        }
+        .asLiveData()
 
     val categoryPages = categoriesUseCase.categories().map { categories ->
         val pageSize = 8
@@ -40,10 +41,6 @@ class EditCategoriesViewModel(
             overallCategories = categoriesUseCase.categories().first()
             overallCategories =
                 overallCategories.filter { !it.hidden } + overallCategories.filter { it.hidden }
-
-
-            liveOrderCategoryList.postValue(overallCategories)
-            liveAddRemoveCategoryList.postValue(overallCategories)
 
             // Check if a new category was added and scroll to it
             if (oldCategories.isNotEmpty() && oldCategories.size < overallCategories.size) {
@@ -84,9 +81,7 @@ class EditCategoriesViewModel(
                             it
                         }
                     }
-                }.sortedBy { it.sortOrder }
-
-                liveOrderCategoryList.postValue(overallCategories)
+                }
 
                 categoriesUseCase.updateCategorySortOrders(
                     overallCategories.map {
@@ -117,9 +112,7 @@ class EditCategoriesViewModel(
                             it
                         }
                     }
-                }.sortedBy { it.sortOrder }
-
-                liveOrderCategoryList.postValue(overallCategories)
+                }
 
                 categoriesUseCase.updateCategorySortOrders(
                     overallCategories.map {

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoryPhrasesFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoryPhrasesFragment.kt
@@ -17,7 +17,7 @@ import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.presets.Phrase
 import com.willowtree.vocable.presets.PresetCategories
 import com.willowtree.vocable.settings.customcategories.CustomCategoryPhraseListFragment
-import com.willowtree.vocable.utils.VocableFragmentStateAdapter
+import com.willowtree.vocable.utils.LegacyFragmentStateAdapter
 import org.koin.androidx.viewmodel.ViewModelOwner
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -167,7 +167,7 @@ class EditCategoryPhrasesFragment : BaseFragment<FragmentEditCategoryPhrasesBind
     }
 
     inner class PhrasesPagerAdapter(fm: FragmentManager) :
-        VocableFragmentStateAdapter<Phrase>(fm, viewLifecycleOwner.lifecycle) {
+        LegacyFragmentStateAdapter<Phrase>(fm, viewLifecycleOwner.lifecycle) {
 
         override fun setItems(items: List<Phrase>) {
             super.setItems(items)

--- a/app/src/test/java/com/willowtree/vocable/FakeCategoriesUseCase.kt
+++ b/app/src/test/java/com/willowtree/vocable/FakeCategoriesUseCase.kt
@@ -5,6 +5,7 @@ import com.willowtree.vocable.room.CategorySortOrder
 import com.willowtree.vocable.utils.locale.LocalesWithText
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 
 @Deprecated("This fake is too complex, tests using it should migrate to integration tests with" +
@@ -23,7 +24,15 @@ class FakeCategoriesUseCase : ICategoriesUseCase {
     )
 
     override fun categories(): Flow<List<Category>> {
-        return _categories
+        return _categories.map {
+            it.sortedBy { category ->
+                if (category.hidden) {
+                    Int.MAX_VALUE
+                } else {
+                    category.sortOrder
+                }
+            }
+        }
     }
 
     override suspend fun updateCategoryName(

--- a/app/src/test/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
@@ -3,6 +3,7 @@ package com.willowtree.vocable.settings
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.willowtree.vocable.FakeCategoriesUseCase
 import com.willowtree.vocable.MainDispatcherRule
+import com.willowtree.vocable.getOrAwaitValue
 import com.willowtree.vocable.presets.createStoredCategory
 import com.willowtree.vocable.settings.editcategories.EditCategoriesPage
 import kotlinx.coroutines.flow.first
@@ -42,14 +43,7 @@ class EditCategoriesViewModelTest {
             listOf(
                 createStoredCategory(categoryId = "1")
             ),
-            vm.orderCategoryList.value
-        )
-
-        assertEquals(
-            listOf(
-                createStoredCategory(categoryId = "1")
-            ),
-            vm.addRemoveCategoryList.value
+            vm.categoryList.getOrAwaitValue()
         )
     }
 
@@ -82,20 +76,7 @@ class EditCategoriesViewModelTest {
                     sortOrder = 1
                 )
             ),
-            vm.orderCategoryList.value
-        )
-        assertEquals(
-            listOf(
-                createStoredCategory(
-                    categoryId = "1",
-                    sortOrder = 1
-                ),
-                createStoredCategory(
-                    categoryId = "2",
-                    sortOrder = 0
-                )
-            ),
-            categoriesUseCase._categories.value
+            vm.categoryList.getOrAwaitValue()
         )
     }
 
@@ -128,20 +109,7 @@ class EditCategoriesViewModelTest {
                     sortOrder = 1
                 )
             ),
-            vm.orderCategoryList.value
-        )
-        assertEquals(
-            listOf(
-                createStoredCategory(
-                    categoryId = "1",
-                    sortOrder = 1
-                ),
-                createStoredCategory(
-                    categoryId = "2",
-                    sortOrder = 0
-                )
-            ),
-            categoriesUseCase._categories.value
+            vm.categoryList.getOrAwaitValue()
         )
     }
 


### PR DESCRIPTION
Description: 
* Partial solution for https://github.com/willowtreeapps/vocable-android/issues/416
* `VocableFragementStateAdapter`:
  * Fix return value of `getItemCount()`
  * Replace `notifyDataSetChanged()` with `notifyItemInserted()` and `notifyItemRemoved()`
* `EditCategoriesFragment`:
  * Use `post {}` for setting `categoryPageNumber` (wasn't always getting set correctly before)
  * Move setting of adapter so that it's called once instead of every time data changes
  * Remove broken setting of current page to "middle" (now defaults to first page)
* Make `LegacyFragmentStateAdapter` for use in other subclasses that haven't been changed yet
* `EditCategoriesViewModel`: replace `liveOrderCategoryList` and `liveAddRemoveCategoryList` in favor of a single `categoryList` that uses `categories()` flow from `categoriesUseCase`
* `EditCategoriesListFragment`: fix crash when removing an element caused pager to go down a page

Screenshots: 
n/a

- [ ] Acceptance Criteria satisfied
- [ ] Regression Testing
