### PR TITLE
380: Decreases individual category padding

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -238,7 +238,7 @@
     <dimen name="edit_category_pager_margin_bottom">44dp</dimen>
     <dimen name="edit_individual_category_padding_start">20dp</dimen>
     <dimen name="edit_individual_category_padding_end">0dp</dimen>
-    <dimen name="edit_individual_category_padding">10dp</dimen>
+    <dimen name="edit_individual_category_padding">5dp</dimen>
     <dimen name="edit_individual_category_margin_top">20dp</dimen>
 
     <!-- Edit Categories List -->


### PR DESCRIPTION
Description: 
Decrease individual category padding from 10dp to 5dp to prevent cutoff in landscape orientation.

Screenshots: 
<img width="796" alt="image" src="https://github.com/willowtreeapps/vocable-android/assets/73308097/8f233892-4380-441d-82f9-f25ffab24e47">

- [x] Acceptance Criteria satisfied
- [ ] Regression Testing
