### PR TITLE
363: Selects the next non-hidden category to display when the currently-displayed category is hidden

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/screens/MainScreen.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/screens/MainScreen.kt
@@ -4,7 +4,6 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import com.willowtree.vocable.R
-import com.willowtree.vocable.customviews.NoSayTextButton
 import com.willowtree.vocable.customviews.VocableButton
 import com.willowtree.vocable.utility.tap
 import org.hamcrest.CoreMatchers.allOf
@@ -48,11 +47,6 @@ class MainScreen {
             onView(withText(phrase)).check(matches(isDisplayed()))
         }
     }
-
-    fun verifyGivenCategoryDisplay(category: String) {
-        onView(withText(category)).check(matches(isDisplayed()))
-    }
-
     // Taps on the selected phrase
     fun tapPhrase(phraseText: String) {
         onView(withText(phraseText)).tap()
@@ -67,34 +61,6 @@ class MainScreen {
     val currentText = onView(withId(R.id.current_text))
     val keyboardNavitgationButton = onView(withId(R.id.keyboard_button))
     val settingsNavigationButton = onView(withId(R.id.settings_button))
-
-    // Settings buttons
-    val editCategoriesButton = onView(withId(R.id.edit_categories_button))
-    val showCategorySwitch = onView(withId(R.id.show_category_switch))
-    val editOptionsBackButton = onView(withId(R.id.edit_options_back_button))
-    val backButton = onView(withId(R.id.back_button))
-    val closeSettingsButton = onView(withId(R.id.settings_close_button))
-    val editGeneralCategoryButton = onView(
-        allOf(
-            instanceOf(NoSayTextButton::class.java),
-            withId(R.id.individual_edit_category_button),
-            withText("General")
-        )
-    )
-    val editRecentCategoryButton = onView(
-        allOf(
-            instanceOf(NoSayTextButton::class.java),
-            withId(R.id.individual_edit_category_button),
-            withText("Recents")
-        )
-    )
-    val editBasicNeedsCategoryButton = onView(
-        allOf(
-            instanceOf(NoSayTextButton::class.java),
-            withId(R.id.individual_edit_category_button),
-            withText("Basic Needs")
-        )
-    )
 
     // Categories and preset phrases
     val categoryBackButton = onView(withId(R.id.category_back_button))

--- a/app/src/androidTest/java/com/willowtree/vocable/screens/MainScreen.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/screens/MainScreen.kt
@@ -4,6 +4,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import com.willowtree.vocable.R
+import com.willowtree.vocable.customviews.NoSayTextButton
 import com.willowtree.vocable.customviews.VocableButton
 import com.willowtree.vocable.utility.tap
 import org.hamcrest.CoreMatchers.allOf
@@ -48,6 +49,10 @@ class MainScreen {
         }
     }
 
+    fun verifyGivenCategoryDisplay(category: String) {
+        onView(withText(category)).check(matches(isDisplayed()))
+    }
+
     // Taps on the selected phrase
     fun tapPhrase(phraseText: String) {
         onView(withText(phraseText)).tap()
@@ -62,6 +67,34 @@ class MainScreen {
     val currentText = onView(withId(R.id.current_text))
     val keyboardNavitgationButton = onView(withId(R.id.keyboard_button))
     val settingsNavigationButton = onView(withId(R.id.settings_button))
+
+    // Settings buttons
+    val editCategoriesButton = onView(withId(R.id.edit_categories_button))
+    val showCategorySwitch = onView(withId(R.id.show_category_switch))
+    val editOptionsBackButton = onView(withId(R.id.edit_options_back_button))
+    val backButton = onView(withId(R.id.back_button))
+    val closeSettingsButton = onView(withId(R.id.settings_close_button))
+    val editGeneralCategoryButton = onView(
+        allOf(
+            instanceOf(NoSayTextButton::class.java),
+            withId(R.id.individual_edit_category_button),
+            withText("General")
+        )
+    )
+    val editRecentCategoryButton = onView(
+        allOf(
+            instanceOf(NoSayTextButton::class.java),
+            withId(R.id.individual_edit_category_button),
+            withText("Recents")
+        )
+    )
+    val editBasicNeedsCategoryButton = onView(
+        allOf(
+            instanceOf(NoSayTextButton::class.java),
+            withId(R.id.individual_edit_category_button),
+            withText("Basic Needs")
+        )
+    )
 
     // Categories and preset phrases
     val categoryBackButton = onView(withId(R.id.category_back_button))

--- a/app/src/androidTest/java/com/willowtree/vocable/tests/MainScreenTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/tests/MainScreenTest.kt
@@ -1,11 +1,9 @@
 package com.willowtree.vocable.tests
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import com.willowtree.vocable.screens.MainScreen
 import com.willowtree.vocable.utility.assertTextMatches
-import org.junit.Ignore
-import org.junit.Rule
+import com.willowtree.vocable.utility.tap
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -50,6 +48,89 @@ class MainScreenTest : BaseTest() {
         mainScreen.apply {
             scrollRightAndTapCurrentCategory(1)
             verifyGivenPhrasesDisplay(defaultPhraseBasicNeeds)
+        }
+    }
+
+    @Test
+    fun verifyNextCategoryShownAfterNavigatingToAndHidingFirstPresetCategory() {
+        mainScreen.apply {
+            // already defaults to being on the first category
+
+            // navigate to Show Category toggle
+            settingsNavigationButton.tap()
+            editCategoriesButton.tap()
+            editGeneralCategoryButton.tap()
+            showCategorySwitch.tap()
+            // exit
+            editOptionsBackButton.tap()
+            backButton.tap()
+            closeSettingsButton.tap()
+
+            // verify basic needs is shown: Category button and Phrases
+            verifyGivenCategoryDisplay("Basic Needs")
+            verifyGivenPhrasesDisplay(defaultPhraseBasicNeeds)
+        }
+    }
+
+    @Test
+    fun verifyFirstCategoryIsShownAfterNavigatingToAndHidingLastPresetCategory() {
+        mainScreen.apply {
+            // navigate to last category
+            categoryBackButton.tap()
+
+            // navigate to Show Category toggle
+            settingsNavigationButton.tap()
+            editCategoriesButton.tap()
+            categoryForwardButton.tap()
+            editRecentCategoryButton.tap()
+            showCategorySwitch.tap()
+            // exit
+            editOptionsBackButton.tap()
+            backButton.tap()
+            closeSettingsButton.tap()
+
+            // verify General is shown
+            verifyGivenCategoryDisplay("General")
+            verifyGivenPhrasesDisplay(defaultPhraseGeneral)
+        }
+    }
+
+    @Test
+    fun verifyNothingChangesWhenNextCategoryIsHidden() {
+        mainScreen.apply {
+            // navigate to Show Category toggle
+            settingsNavigationButton.tap()
+            editCategoriesButton.tap()
+            editBasicNeedsCategoryButton.tap()
+            showCategorySwitch.tap()
+            // exit
+            editOptionsBackButton.tap()
+            backButton.tap()
+            closeSettingsButton.tap()
+
+            // verify General is shown
+            verifyGivenCategoryDisplay("General")
+            verifyGivenPhrasesDisplay(defaultPhraseGeneral)
+        }
+    }
+
+    @Test
+    fun verifyNothingChangesWhenPreviousCategoryIsHidden() {
+        mainScreen.apply {
+            // navigate to Show Category toggle
+            settingsNavigationButton.tap()
+            editCategoriesButton.tap()
+            categoryForwardButton.tap()
+            editRecentCategoryButton.tap()
+            showCategorySwitch.tap()
+            // exit
+            editOptionsBackButton.tap()
+            backButton.tap()
+            closeSettingsButton.tap()
+
+            // verify General is shown
+            verifyGivenCategoryDisplay("General")
+            verifyGivenPhrasesDisplay(defaultPhraseGeneral)
         }
     }
 }

--- a/app/src/androidTest/java/com/willowtree/vocable/tests/MainScreenTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/tests/MainScreenTest.kt
@@ -3,7 +3,6 @@ package com.willowtree.vocable.tests
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.willowtree.vocable.screens.MainScreen
 import com.willowtree.vocable.utility.assertTextMatches
-import com.willowtree.vocable.utility.tap
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -48,89 +47,6 @@ class MainScreenTest : BaseTest() {
         mainScreen.apply {
             scrollRightAndTapCurrentCategory(1)
             verifyGivenPhrasesDisplay(defaultPhraseBasicNeeds)
-        }
-    }
-
-    @Test
-    fun verifyNextCategoryShownAfterNavigatingToAndHidingFirstPresetCategory() {
-        mainScreen.apply {
-            // already defaults to being on the first category
-
-            // navigate to Show Category toggle
-            settingsNavigationButton.tap()
-            editCategoriesButton.tap()
-            editGeneralCategoryButton.tap()
-            showCategorySwitch.tap()
-            // exit
-            editOptionsBackButton.tap()
-            backButton.tap()
-            closeSettingsButton.tap()
-
-            // verify basic needs is shown: Category button and Phrases
-            verifyGivenCategoryDisplay("Basic Needs")
-            verifyGivenPhrasesDisplay(defaultPhraseBasicNeeds)
-        }
-    }
-
-    @Test
-    fun verifyFirstCategoryIsShownAfterNavigatingToAndHidingLastPresetCategory() {
-        mainScreen.apply {
-            // navigate to last category
-            categoryBackButton.tap()
-
-            // navigate to Show Category toggle
-            settingsNavigationButton.tap()
-            editCategoriesButton.tap()
-            categoryForwardButton.tap()
-            editRecentCategoryButton.tap()
-            showCategorySwitch.tap()
-            // exit
-            editOptionsBackButton.tap()
-            backButton.tap()
-            closeSettingsButton.tap()
-
-            // verify General is shown
-            verifyGivenCategoryDisplay("General")
-            verifyGivenPhrasesDisplay(defaultPhraseGeneral)
-        }
-    }
-
-    @Test
-    fun verifyNothingChangesWhenNextCategoryIsHidden() {
-        mainScreen.apply {
-            // navigate to Show Category toggle
-            settingsNavigationButton.tap()
-            editCategoriesButton.tap()
-            editBasicNeedsCategoryButton.tap()
-            showCategorySwitch.tap()
-            // exit
-            editOptionsBackButton.tap()
-            backButton.tap()
-            closeSettingsButton.tap()
-
-            // verify General is shown
-            verifyGivenCategoryDisplay("General")
-            verifyGivenPhrasesDisplay(defaultPhraseGeneral)
-        }
-    }
-
-    @Test
-    fun verifyNothingChangesWhenPreviousCategoryIsHidden() {
-        mainScreen.apply {
-            // navigate to Show Category toggle
-            settingsNavigationButton.tap()
-            editCategoriesButton.tap()
-            categoryForwardButton.tap()
-            editRecentCategoryButton.tap()
-            showCategorySwitch.tap()
-            // exit
-            editOptionsBackButton.tap()
-            backButton.tap()
-            closeSettingsButton.tap()
-
-            // verify General is shown
-            verifyGivenCategoryDisplay("General")
-            verifyGivenPhrasesDisplay(defaultPhraseGeneral)
         }
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/presets/PresetsViewModel.kt
@@ -34,7 +34,20 @@ class PresetsViewModel(
         categoriesUseCase.categories(),
         liveSelectedCategoryId
     ) { categories, selectedId ->
-        categories.find { it.categoryId == selectedId }
+        val currentCategory = categories.find { it.categoryId == selectedId }
+        if (currentCategory?.hidden == true) {
+            val newSortOrder = (currentCategory.sortOrder + 1)
+            val newCategory = categories.find { it.sortOrder == newSortOrder}
+            if (newCategory != null) {
+                liveSelectedCategoryId.update { newCategory.categoryId }
+                categories.find { it.sortOrder == newSortOrder}
+            } else {
+                liveSelectedCategoryId.update { categories.first().categoryId }
+                categories.first()
+            }
+        } else {
+            currentCategory
+        }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), null)
     val selectedCategoryLiveData: LiveData<Category?> = selectedCategory.asLiveData()
 

--- a/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PresetsViewModelTest.kt
@@ -114,6 +114,148 @@ class PresetsViewModelTest {
         )
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `selected category is hidden and next immediate category is shown`() = runTest(UnconfinedTestDispatcher()) {
+        fakeCategoriesUseCase._categories.update {
+            listOf(
+                Category.StoredCategory(
+                    categoryId = "1",
+                    localizedName = LocalesWithText(mapOf("en_US" to "category")),
+                    hidden = true,
+                    sortOrder = 0
+                ),
+                Category.StoredCategory(
+                    categoryId = "2",
+                    localizedName = LocalesWithText(mapOf("en_US" to "second category")),
+                    hidden = false,
+                    sortOrder = 1
+                )
+            )
+        }
+
+        val vm = createViewModel()
+
+        vm.onCategorySelected("1")
+
+        var category: Category? = null
+        val job = launch {
+            vm.selectedCategory.collect {
+                category = it
+            }
+        }
+        job.cancel()
+
+        assertEquals(
+            Category.StoredCategory(
+                categoryId = "2",
+                localizedName = LocalesWithText(mapOf("en_US" to "second category")),
+                hidden = false,
+                sortOrder = 1
+            ),
+            category
+        )
+
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `selected category (last in list) is hidden and first category is shown`() = runTest(UnconfinedTestDispatcher()) {
+        fakeCategoriesUseCase._categories.update {
+            listOf(
+                Category.StoredCategory(
+                    categoryId = "1",
+                    localizedName = LocalesWithText(mapOf("en_US" to "category")),
+                    hidden = false,
+                    sortOrder = 0
+                ),
+                Category.StoredCategory(
+                    categoryId = "2",
+                    localizedName = LocalesWithText(mapOf("en_US" to "second category")),
+                    hidden = false,
+                    sortOrder = 1
+                ),
+                Category.StoredCategory(
+                    categoryId = "3",
+                    localizedName = LocalesWithText(mapOf("en_US" to "third category")),
+                    hidden = true,
+                    sortOrder = 2
+                )
+            )
+        }
+
+        val vm = createViewModel()
+
+        vm.onCategorySelected("3")
+
+        var category: Category? = null
+        val job = launch {
+            vm.selectedCategory.collect {
+                category = it
+            }
+        }
+        job.cancel()
+
+        assertEquals(
+            Category.StoredCategory(
+                categoryId = "1",
+                localizedName = LocalesWithText(mapOf("en_US" to "category")),
+                hidden = false,
+                sortOrder = 0
+            ),
+            category
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `selected category is hidden and next non-hidden category is shown`() = runTest(UnconfinedTestDispatcher()) {
+        fakeCategoriesUseCase._categories.update {
+            listOf(
+                Category.StoredCategory(
+                    categoryId = "1",
+                    localizedName = LocalesWithText(mapOf("en_US" to "category")),
+                    hidden = true,
+                    sortOrder = 0
+                ),
+                Category.StoredCategory(
+                    categoryId = "2",
+                    localizedName = LocalesWithText(mapOf("en_US" to "second category")),
+                    hidden = false,
+                    sortOrder = 1
+                ),
+                Category.StoredCategory(
+                    categoryId = "3",
+                    localizedName = LocalesWithText(mapOf("en_US" to "third category")),
+                    hidden = true,
+                    sortOrder = 2
+                )
+            )
+        }
+
+        val vm = createViewModel()
+
+        vm.onCategorySelected("3")
+
+        var category: Category? = null
+        val job = launch {
+            vm.selectedCategory.collect {
+                category = it
+            }
+        }
+        job.cancel()
+
+        assertEquals(
+            Category.StoredCategory(
+                categoryId = "2",
+                localizedName = LocalesWithText(mapOf("en_US" to "second category")),
+                hidden = false,
+                sortOrder = 1
+            ),
+            category
+        )
+    }
+
     @Test
     fun `current phrases updated when category ID changed`() {
         fakePhrasesUseCase._allCategories.update {


### PR DESCRIPTION
Description: 
When a user hides the currently-displayed category, looks for and select the next non-hidden category. Displays the Category label and Phrases of the newly-selected, non-hidden category. 

Defaults to looking for the next non-hidden category to the "right". 

Addresses #363 

- [x] Acceptance Criteria satisfied
- [ ] Regression Testing
