### PR TITLE
Updates settings layouts in landscape

### DIFF
--- a/app/src/main/res/layout-land/category_edit_button.xml
+++ b/app/src/main/res/layout-land/category_edit_button.xml
@@ -14,34 +14,35 @@
         android:id="@+id/individual_edit_category_button"
         style="@style/IndividualCategoryEditButton"
         android:layout_width="0dp"
-        android:layout_height="@dimen/settings_edit_individual_category_arrow_height"
+        android:layout_height="0dp"
         android:paddingStart="@dimen/edit_individual_category_padding_start"
         android:paddingEnd="@dimen/edit_individual_category_padding_end"
-        android:padding="@dimen/edit_individual_category_padding"
         android:layout_marginStart="@dimen/settings_option_button_margin"
         android:layout_marginTop="@dimen/settings_edit_individual_category_arrow_top"
         android:text="@string/settings"
         android:textStyle="bold"
         app:layout_constraintStart_toEndOf="@+id/move_category_down_button"
         app:layout_constraintEnd_toEndOf="@id/category_container"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
     <com.willowtree.vocable.customviews.VocableImageButton
         android:id="@+id/move_category_up_button"
         android:layout_width="@dimen/settings_edit_individual_category_arrow_width"
-        android:layout_height="@dimen/settings_edit_individual_category_arrow_height"
+        android:layout_height="0dp"
         android:layout_marginTop="@dimen/settings_edit_individual_category_arrow_top"
         android:padding="@dimen/settings_edit_individual_category_arrow_padding"
         android:scaleType="centerInside"
         android:background="@drawable/button_default_background"
         android:src="@drawable/ic_up_arrow"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
     <com.willowtree.vocable.customviews.VocableImageButton
         android:id="@+id/move_category_down_button"
         android:layout_width="@dimen/settings_edit_individual_category_arrow_width"
-        android:layout_height="@dimen/settings_edit_individual_category_arrow_height"
+        android:layout_height="0dp"
         android:layout_marginTop="@dimen/settings_edit_individual_category_arrow_top"
         android:layout_marginStart="@dimen/settings_edit_individual_category_arrow_top"
         android:background="@drawable/button_default_background"
@@ -49,6 +50,7 @@
         android:padding="@dimen/settings_edit_individual_category_arrow_padding"
         android:scaleType="centerInside"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/move_category_up_button" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-land/fragment_edit_category_menu.xml
+++ b/app/src/main/res/layout-land/fragment_edit_category_menu.xml
@@ -66,6 +66,10 @@
             android:id="@+id/show_category_switch"
             android:layout_rowWeight="1"
             android:layout_columnWeight="1"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="@dimen/edit_individual_category_menu_margin"
+            android:layout_marginEnd="@dimen/edit_individual_category_menu_margin"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -27,7 +27,7 @@
     <dimen name="edit_action_delete_width">88dp</dimen>
 
     <!-- Settings Options -->
-    <dimen name="settings_options_margin_bottom">16dp</dimen>
+    <dimen name="settings_options_margin_bottom">8dp</dimen>
     <dimen name="settings_link_button_bottom_margin">20dp</dimen>
     <dimen name="settings_options_margin_top">24dp</dimen>
     <dimen name="settings_version_text_bottom_margin">32dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -171,7 +171,7 @@
     <dimen name="settings_options_margin_top">32dp</dimen>
     <dimen name="settings_options_margin_bottom">64dp</dimen>
     <dimen name="setting_options_margin_horizontal">24dp</dimen>
-    <dimen name="settings_link_button_height">48dp</dimen>
+    <dimen name="settings_link_button_height">36dp</dimen>
     <dimen name="settings_link_button_end_margin">8dp</dimen>
     <dimen name="settings_link_button_bottom_margin">88dp</dimen>
     <dimen name="settings_link_button_padding">8dp</dimen>
@@ -240,6 +240,7 @@
     <dimen name="edit_individual_category_padding_end">0dp</dimen>
     <dimen name="edit_individual_category_padding">5dp</dimen>
     <dimen name="edit_individual_category_margin_top">20dp</dimen>
+    <dimen name="edit_individual_category_menu_margin">8dp</dimen>
 
     <!-- Edit Categories List -->
     <dimen name="edit_categories_list_button_width">56dp</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -319,7 +319,6 @@
         <item name="android:layout_rowWeight">1</item>
         <item name="android:layout_columnWeight">1</item>
         <item name="android:layout_marginEnd">@dimen/settings_option_button_margin</item>
-        <item name="android:layout_marginBottom">@dimen/settings_option_button_margin</item>
         <item name="android:background">@drawable/button_default_background</item>
         <item name="android:drawableEnd">@drawable/arrow_right_32dp</item>
         <item name="android:gravity">center_vertical</item>


### PR DESCRIPTION
Description: 
1. Spaces out the "Categories and Phrases", "Timing and Sensitivity", and "Selection Mode" buttons in Settings page
2. Expands height of up/down arrows and Category name buttons in "Categories and Phrases" page
3. Expands height of "Rename Category" and "Edit Phrases" buttons in individual Category edit menu

Screenshots: 
1. 
Before:
![image](https://github.com/willowtreeapps/vocable-android/assets/73308097/a7a58341-67f7-4dc7-92f5-c21923984025)

After:
![image](https://github.com/willowtreeapps/vocable-android/assets/73308097/95114e58-f106-472c-997a-d81ebdb061f7)

2. 
Before: 
![image](https://github.com/willowtreeapps/vocable-android/assets/73308097/ae70affb-cdac-4444-9716-e9a7dcd65bf3)

After:
![image](https://github.com/willowtreeapps/vocable-android/assets/73308097/eddb7936-a123-4f5d-810b-90a69a2372a2)

3. 
Before:
![image](https://github.com/willowtreeapps/vocable-android/assets/73308097/7619742d-39a3-4166-b3de-6c3174afaf2f)

After:
![image](https://github.com/willowtreeapps/vocable-android/assets/73308097/cd580fa1-70ec-4148-98b9-a60a1394c3b7)

- [ ] Acceptance Criteria satisfied
- [ ] Regression Testing
