### PR TITLE
Conditionally set run ID when downloading artifacts

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -21,9 +21,11 @@ jobs:
     steps:
       - uses: haya14busa/action-workflow_run-status@v1
         if: ${{ github.event_name == 'workflow_run' }}
+      - name: Set RUN_ID
+        run: echo "RUN_ID=${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || github.run_id }}" >> $GITHUB_ENV
       - uses: actions/download-artifact@v4
         with:
-          run-id: ${{github.event.workflow_run.id }}
+          run-id: ${{ env.RUN_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Decode Firebase Service Account JSON


### PR DESCRIPTION
This enables the workflow to be reused.
