### PR TITLE
Check out and build code as part of the release upload

### DIFF
--- a/.github/workflows/pre-release-upload.yml
+++ b/.github/workflows/pre-release-upload.yml
@@ -12,6 +12,16 @@ jobs:
     needs: device-tests
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        
+      - name: Set Up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
       - name: Decode Keystore
         env:
           ENCODED_RELEASE_KEYSTORE: ${{ secrets.ENCODED_RELEASE_KEYSTORE }}


### PR DESCRIPTION
Could see a reason for this to be its own job and it uploading an artifact, but this is fine for now.
