### PR TITLE
Push updating phrase logic down into the use case

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
@@ -64,7 +64,8 @@ class CategoriesUseCaseTest {
                 storedPhrasesRepository,
                 presetPhrasesRepository,
                 FakeDateProvider(),
-                FakeUUIDProvider()
+                FakeUUIDProvider(),
+                FakeLocaleProvider()
             )
         )
     }

--- a/app/src/androidTest/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModelTest.kt
@@ -68,7 +68,8 @@ class AddUpdateCategoryViewModelTest {
             storedPhrasesRepository,
             presetPhrasesRepository,
             FakeDateProvider(),
-            FakeUUIDProvider()
+            FakeUUIDProvider(),
+            FakeLocaleProvider()
         )
     )
 

--- a/app/src/androidTest/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
@@ -60,7 +60,8 @@ class EditCategoriesViewModelTest {
             storedPhrasesRepository,
             presetPhrasesRepository,
             FakeDateProvider(),
-            FakeUUIDProvider()
+            FakeUUIDProvider(),
+            FakeLocaleProvider()
         )
     )
 

--- a/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/AppKoinModule.kt
@@ -28,9 +28,9 @@ import com.willowtree.vocable.utils.FaceTrackingPermissions
 import com.willowtree.vocable.utils.IFaceTrackingPermissions
 import com.willowtree.vocable.utils.ILocalizedResourceUtility
 import com.willowtree.vocable.utils.IVocableSharedPreferences
-import com.willowtree.vocable.utils.JavaDateProvider
 import com.willowtree.vocable.utils.IdlingResourceContainer
 import com.willowtree.vocable.utils.IdlingResourceContainerImpl
+import com.willowtree.vocable.utils.JavaDateProvider
 import com.willowtree.vocable.utils.RandomUUIDProvider
 import com.willowtree.vocable.utils.UUIDProvider
 import com.willowtree.vocable.utils.VocableEnvironment
@@ -90,7 +90,7 @@ val vocableKoinModule = module {
     single { Moshi.Builder().add(KotlinJsonAdapterFactory()).build() }
     single { LocalizedResourceUtility(androidContext()) } bind ILocalizedResourceUtility::class
     single { CategoriesUseCase(get(), get(), get(), get(), get()) } bind ICategoriesUseCase::class
-    single { PhrasesUseCase(get(), get(), get(), get(), get()) } bind IPhrasesUseCase::class
+    single { PhrasesUseCase(get(), get(), get(), get(), get(), get()) } bind IPhrasesUseCase::class
     single { RandomUUIDProvider() } bind UUIDProvider::class
     single { JavaDateProvider() } bind DateProvider::class
     single { JavaLocaleProvider() } bind LocaleProvider::class

--- a/app/src/main/java/com/willowtree/vocable/IPhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/IPhrasesUseCase.kt
@@ -11,7 +11,7 @@ interface IPhrasesUseCase {
 
     suspend fun deletePhrase(phraseId: String)
 
-    suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText)
+    suspend fun updatePhrase(phraseId: String, updatedPhrase: String)
 
     suspend fun addPhrase(localizedUtterance: LocalesWithText, parentCategoryId: String)
 }

--- a/app/src/main/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/AddUpdateCategoryViewModel.kt
@@ -45,7 +45,7 @@ class AddUpdateCategoryViewModel(
                 is Category.Recents -> throw IllegalArgumentException("Cannot update Recents category name!")
             }
 
-            val updatedLocalizedNames: LocalesWithText = localesWithText.set(localeProvider.getDefaultLocaleString(), updatedName)
+            val updatedLocalizedNames: LocalesWithText = localesWithText.with(localeProvider.getDefaultLocaleString(), updatedName)
 
             categoriesUseCase.updateCategoryName(toUpdate.categoryId, updatedLocalizedNames)
             liveShowCategoryUpdateMessage.postValue(true)

--- a/app/src/main/java/com/willowtree/vocable/settings/EditPhrasesKeyboardFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditPhrasesKeyboardFragment.kt
@@ -9,10 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.willowtree.vocable.R
-import com.willowtree.vocable.presets.CustomPhrase
 import com.willowtree.vocable.presets.Phrase
-import com.willowtree.vocable.presets.PresetPhrase
-import com.willowtree.vocable.utils.locale.LocalesWithText
 
 class EditPhrasesKeyboardFragment : EditKeyboardFragment() {
 
@@ -50,13 +47,7 @@ class EditPhrasesKeyboardFragment : EditKeyboardFragment() {
             if (!isDefaultTextVisible()) {
                 binding.keyboardInput.text.let { text ->
                     if (text.isNotBlank()) {
-                        val localesWithText = when (val savingPhrase = phrase) {
-                            is CustomPhrase -> {
-                                savingPhrase.localizedUtterance ?: LocalesWithText(emptyMap())
-                            }
-                            is PresetPhrase -> LocalesWithText(mapOf("en" to text.toString()))
-                        }
-                        viewModel.updatePhrase(phrase.phraseId, localesWithText)
+                        viewModel.updatePhrase(phrase.phraseId, text.toString())
                         addNewPhrase = false
                     }
                 }

--- a/app/src/main/java/com/willowtree/vocable/settings/EditPhrasesViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditPhrasesViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.PhrasesUseCase
-import com.willowtree.vocable.utils.locale.LocalesWithText
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -17,9 +16,9 @@ class EditPhrasesViewModel : ViewModel(), KoinComponent {
     private val liveShowPhraseAdded = MutableLiveData<Boolean>()
     val showPhraseAdded: LiveData<Boolean> = liveShowPhraseAdded
 
-    fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText) {
+    fun updatePhrase(phraseId: String, newText: String) {
         viewModelScope.launch {
-            phrasesUseCase.updatePhrase(phraseId, localizedUtterance)
+            phrasesUseCase.updatePhrase(phraseId, newText)
             liveShowPhraseAdded.postValue(true)
         }
     }

--- a/app/src/main/java/com/willowtree/vocable/utils/locale/LocalesWithText.kt
+++ b/app/src/main/java/com/willowtree/vocable/utils/locale/LocalesWithText.kt
@@ -27,6 +27,8 @@ data class LocalesWithText(
     val localesTextMap: Map<LocaleString, String>
 ) : Parcelable {
 
+    constructor(vararg pairs: Pair<LocaleString, String>) : this(mapOf(*pairs))
+
     /**
      * Gets the string corresponding to the given localeString.
      * @param localeString The localeString to match against
@@ -46,7 +48,7 @@ data class LocalesWithText(
      * @param text for the localeString
      * @return A new LocalesWithText with the given localeString and text added to the map
      */
-    operator fun set(localeString: LocaleString, text: String): LocalesWithText {
+    fun with(localeString: LocaleString, text: String): LocalesWithText {
         return LocalesWithText(localesTextMap.toMutableMap().apply {
             this[localeString] = text
         })

--- a/app/src/test/java/com/willowtree/vocable/FakePhrasesUseCase.kt
+++ b/app/src/test/java/com/willowtree/vocable/FakePhrasesUseCase.kt
@@ -45,7 +45,7 @@ class FakePhrasesUseCase : IPhrasesUseCase {
 
     override suspend fun deletePhrase(phraseId: String) = error("Not implemented")
 
-    override suspend fun updatePhrase(phraseId: String, localizedUtterance: LocalesWithText) {
+    override suspend fun updatePhrase(phraseId: String, updatedPhrase: String) {
         error("Not implemented")
     }
 


### PR DESCRIPTION
Now PhrasesUseCase can handle the difference between stored vs preset phrases, vs the UI. Update tests accordingly, now we can test this case more easily. Properly set phrase to current locale.