### PR TITLE
#566: Replaces RecyclerView with GridView on edit phrases screen

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/settings/customcategories/CustomCategoryPhraseListFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/customcategories/CustomCategoryPhraseListFragment.kt
@@ -1,11 +1,11 @@
 package com.willowtree.vocable.settings.customcategories
 
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.navigation.fragment.findNavController
-import androidx.recyclerview.widget.GridLayoutManager
 import com.willowtree.vocable.BaseFragment
 import com.willowtree.vocable.BindingInflater
 import com.willowtree.vocable.R
@@ -13,8 +13,7 @@ import com.willowtree.vocable.databinding.FragmentCustomCategoryPhraseListBindin
 import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.presets.Phrase
 import com.willowtree.vocable.settings.EditCategoryPhrasesFragmentDirections
-import com.willowtree.vocable.settings.customcategories.adapter.CustomCategoryPhraseAdapter
-import com.willowtree.vocable.utils.ItemOffsetDecoration
+import com.willowtree.vocable.settings.customcategories.adapter.CustomCategoryPhraseGridAdapter
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class CustomCategoryPhraseListFragment : BaseFragment<FragmentCustomCategoryPhraseListBinding>() {
@@ -37,7 +36,10 @@ class CustomCategoryPhraseListFragment : BaseFragment<FragmentCustomCategoryPhra
     private lateinit var category: Category
 
     private val onPhraseEdit = { phrase: Phrase ->
-        val action = EditCategoryPhrasesFragmentDirections.actionEditCategoryPhrasesFragmentToEditPhrasesKeyboardFragment(phrase)
+        val action =
+            EditCategoryPhrasesFragmentDirections.actionEditCategoryPhrasesFragmentToEditPhrasesKeyboardFragment(
+                phrase
+            )
         if (findNavController().currentDestination?.id == R.id.editCategoryPhrasesFragment) {
             findNavController().navigate(action)
         }
@@ -63,16 +65,13 @@ class CustomCategoryPhraseListFragment : BaseFragment<FragmentCustomCategoryPhra
 
         phrases?.let {
             with(binding.customCategoryPhraseHolder) {
-                layoutManager = GridLayoutManager(requireContext(), numColumns)
-                addItemDecoration(
-                    ItemOffsetDecoration(
-                        requireContext(),
-                        R.dimen.edit_category_phrase_button_margin,
-                        it.size
-                    )
+                setNumColumns(numColumns)
+                adapter = CustomCategoryPhraseGridAdapter(
+                    context = requireContext(),
+                    phrases = it,
+                    onPhraseEdit = onPhraseEdit,
+                    onPhraseDelete = onPhraseDelete,
                 )
-                setHasFixedSize(true)
-                adapter = CustomCategoryPhraseAdapter(it, onPhraseEdit, onPhraseDelete)
             }
         }
     }

--- a/app/src/main/java/com/willowtree/vocable/settings/customcategories/adapter/CustomCategoryPhraseGridAdapter.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/customcategories/adapter/CustomCategoryPhraseGridAdapter.kt
@@ -1,0 +1,62 @@
+package com.willowtree.vocable.settings.customcategories.adapter
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import androidx.core.view.isInvisible
+import com.willowtree.vocable.R
+import com.willowtree.vocable.databinding.EditCustomCategoryPhraseItemBinding
+import com.willowtree.vocable.presets.Phrase
+import org.koin.core.component.KoinComponent
+
+class CustomCategoryPhraseGridAdapter(
+    context: Context,
+    private var phrases: List<Phrase>,
+    private val onPhraseEdit: (Phrase) -> Unit,
+    private val onPhraseDelete: (Phrase) -> Unit
+) :
+    ArrayAdapter<Phrase>(
+        context,
+        R.layout.edit_custom_category_phrase_item
+    ),
+    KoinComponent {
+
+    private lateinit var binding: EditCustomCategoryPhraseItemBinding
+
+    init {
+        addAll(phrases)
+    }
+
+    // Linter warns about using ViewHolder for smoother scrolling, but we shouldn't be scrolling here anyway
+    @SuppressLint("ViewHolder")
+    override fun getView(position: Int, itemView: View?, parent: ViewGroup): View {
+        binding =
+            EditCustomCategoryPhraseItemBinding.inflate(LayoutInflater.from(context), parent, false)
+
+        val listItemView: View = binding.root
+
+        listItemView.isInvisible = true
+        binding.removeCategoryButton.action = {
+            onPhraseDelete(phrases[position])
+        }
+        binding.phraseTextButton.action = {
+            onPhraseEdit(phrases[position])
+        }
+        binding.root.setPaddingRelative(
+            0,
+            context.resources.getDimensionPixelSize(R.dimen.edit_category_phrase_button_margin),
+            0,
+            0
+        )
+        binding.phraseTextButton.text = phrases[position].text(context)
+        parent.post {
+            with(listItemView) {
+                isInvisible = false
+            }
+        }
+        return listItemView
+    }
+}

--- a/app/src/main/res/layout/fragment_custom_category_phrase_list.xml
+++ b/app/src/main/res/layout/fragment_custom_category_phrase_list.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <GridView
         android:id="@+id/custom_category_phrase_holder"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />


### PR DESCRIPTION
DOES NOT RESOLVE ENTIRE BUG

Description: 
Replaces the RecyclerView in CustomCategoryPhraseListFragment with a GridView - the eventual goal is to dynamically measure the number of phrases that can fit on the screen so that there won't be scrolling; ergo, there's no need for a RecyclerView.

I did my best to accurately duplicate the existing design but please don't hesitate to raise any issues you see!

Screenshots: 
Edit Phrase screen ("General" category) - new GridView version

![GridView edit phrases](https://github.com/user-attachments/assets/0e4ab359-8a09-4e15-a8a7-beb309f9d9c1)

